### PR TITLE
feat: auction status guards and lot mutation lock (FEAT-004)

### DIFF
--- a/client/app/crm/auctions/[auctionId]/CreateLot.button.test.tsx
+++ b/client/app/crm/auctions/[auctionId]/CreateLot.button.test.tsx
@@ -1,7 +1,39 @@
 // @vitest-environment jsdom
-import { describe, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/app/crm/auctions/[auctionId]/CreateLot.modal', () => ({
+  createLotModal: { show: vi.fn() },
+}));
+
+vi.mock('@/app/crm/auctions/[auctionId]/LotImages.modal', () => ({
+  lotImagesModal: { show: vi.fn() },
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+vi.mock('@/src/modules/notifications/NotifcationContext', () => ({
+  useErrorNotification: () => vi.fn(),
+}));
+
+import CreateLotButton from './CreateLot.button';
 
 describe('CreateLotButton', () => {
-  it.todo('renders as a disabled button when disabled prop is true');
-  it.todo('renders as an enabled button when disabled prop is false');
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders as a disabled button when disabled prop is true', () => {
+    render(<CreateLotButton auctionId="auction-1" disabled={true} />);
+
+    expect(screen.getByRole('button', { name: /add/i })).toBeDisabled();
+  });
+
+  it('renders as an enabled button when disabled prop is false', () => {
+    render(<CreateLotButton auctionId="auction-1" disabled={false} />);
+
+    expect(screen.getByRole('button', { name: /add/i })).not.toBeDisabled();
+  });
 });

--- a/client/app/crm/auctions/[auctionId]/CreateLot.button.test.tsx
+++ b/client/app/crm/auctions/[auctionId]/CreateLot.button.test.tsx
@@ -1,0 +1,7 @@
+// @vitest-environment jsdom
+import { describe, it } from 'vitest';
+
+describe('CreateLotButton', () => {
+  it.todo('renders as a disabled button when disabled prop is true');
+  it.todo('renders as an enabled button when disabled prop is false');
+});

--- a/client/app/crm/auctions/[auctionId]/CreateLot.button.tsx
+++ b/client/app/crm/auctions/[auctionId]/CreateLot.button.tsx
@@ -10,9 +10,10 @@ import { lotImagesModal } from '@/app/crm/auctions/[auctionId]/LotImages.modal';
 
 type Props = {
   auctionId: Auction['id'];
+  disabled?: boolean;
 };
 
-const CreateLotButton = ({ auctionId }: Props) => {
+const CreateLotButton = ({ auctionId, disabled }: Props) => {
   const router = useRouter();
   const handleError = useErrorNotification();
 
@@ -39,7 +40,7 @@ const CreateLotButton = ({ auctionId }: Props) => {
   };
 
   return (
-    <Button className="min-w-[100px]" onClick={handleCreateClick}>
+    <Button className="min-w-[100px]" onClick={handleCreateClick} disabled={disabled}>
       <Plus /> Add
     </Button>
   );

--- a/client/app/crm/auctions/[auctionId]/DeleteLot.button.test.tsx
+++ b/client/app/crm/auctions/[auctionId]/DeleteLot.button.test.tsx
@@ -1,0 +1,7 @@
+// @vitest-environment jsdom
+import { describe, it } from 'vitest';
+
+describe('DeleteLotButton', () => {
+  it.todo('renders as a disabled button when disabled prop is true');
+  it.todo('renders as an enabled button when disabled prop is false');
+});

--- a/client/app/crm/auctions/[auctionId]/DeleteLot.button.test.tsx
+++ b/client/app/crm/auctions/[auctionId]/DeleteLot.button.test.tsx
@@ -1,7 +1,42 @@
 // @vitest-environment jsdom
-import { describe, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/src/modules/modals/ConfirmModal', () => ({
+  confirmModal: { show: vi.fn() },
+}));
+
+vi.mock('@/src/api/auctions-api-client/requests/lots', () => ({
+  deleteLot: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+vi.mock('@/src/modules/notifications/NotifcationContext', () => ({
+  useErrorNotification: () => vi.fn(),
+  useNotification: () => ({ showToast: vi.fn() }),
+}));
+
+import { DeleteLotButton } from './DeleteLot.button';
+
+const lot = { id: 'lot-1', name: 'Watch' } as any;
 
 describe('DeleteLotButton', () => {
-  it.todo('renders as a disabled button when disabled prop is true');
-  it.todo('renders as an enabled button when disabled prop is false');
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders as a disabled button when disabled prop is true', () => {
+    render(<DeleteLotButton lot={lot} auctionId="auction-1" disabled={true} />);
+
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('renders as an enabled button when disabled prop is false', () => {
+    render(<DeleteLotButton lot={lot} auctionId="auction-1" disabled={false} />);
+
+    expect(screen.getByRole('button')).not.toBeDisabled();
+  });
 });

--- a/client/app/crm/auctions/[auctionId]/DeleteLot.button.tsx
+++ b/client/app/crm/auctions/[auctionId]/DeleteLot.button.tsx
@@ -15,9 +15,10 @@ import { Trash2 } from 'lucide-react';
 type Props = {
   lot: Lot;
   auctionId: Auction['id'];
+  disabled?: boolean;
 };
 
-export const DeleteLotButton = ({ lot, auctionId }: Props) => {
+export const DeleteLotButton = ({ lot, auctionId, disabled }: Props) => {
   const { showToast } = useNotification();
   const handleError = useErrorNotification();
   const router = useRouter();
@@ -46,7 +47,7 @@ export const DeleteLotButton = ({ lot, auctionId }: Props) => {
   };
 
   return (
-    <Button variant="ghost" size="icon" onClick={handleDelete} title={`Delete ${lot.name}`}>
+    <Button variant="ghost" size="icon" onClick={handleDelete} title={`Delete ${lot.name}`} disabled={disabled}>
       <Trash2 />
     </Button>
   );

--- a/client/app/crm/auctions/[auctionId]/LotsList.table.tsx
+++ b/client/app/crm/auctions/[auctionId]/LotsList.table.tsx
@@ -28,7 +28,7 @@ const LotStatusBadge = ({ status }: { status: LotStatus }) => {
   return <Badge variant={variantMap[status]}>{status}</Badge>;
 };
 
-const getColumns = (auctionId: Auction['id']): Columns<Lot> => [
+const getColumns = (auctionId: Auction['id'], isLocked?: boolean): Columns<Lot> => [
   {
     header: 'Name',
     render: (lot) => lot.name,
@@ -62,17 +62,17 @@ const getColumns = (auctionId: Auction['id']): Columns<Lot> => [
     align: 'center',
     render: (lot) => (
       <>
-        <DeleteLotButton auctionId={auctionId} lot={lot} />
-        <ManageLotImagesButton auctionId={auctionId} lot={lot} />
+        <DeleteLotButton auctionId={auctionId} lot={lot} disabled={isLocked} />
+        <ManageLotImagesButton auctionId={auctionId} lot={lot} disabled={isLocked} />
       </>
     ),
   },
 ];
 
-const LotsList = async ({ auctionId }: { auctionId: Auction['id'] }) => {
+const LotsList = async ({ auctionId, isLocked }: { auctionId: Auction['id']; isLocked?: boolean }) => {
   const lots = await fetchLotsServer(auctionId);
 
-  const columns = getColumns(auctionId);
+  const columns = getColumns(auctionId, isLocked);
 
   return <DataTable data={lots} columns={columns} />;
 };

--- a/client/app/crm/auctions/[auctionId]/ManageLotImages.button.test.tsx
+++ b/client/app/crm/auctions/[auctionId]/ManageLotImages.button.test.tsx
@@ -1,7 +1,37 @@
 // @vitest-environment jsdom
-import { describe, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/app/crm/auctions/[auctionId]/LotImages.modal', () => ({
+  lotImagesModal: { show: vi.fn() },
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+vi.mock('@/src/modules/notifications/NotifcationContext', () => ({
+  useErrorNotification: () => vi.fn(),
+}));
+
+import ManageLotImagesButton from './ManageLotImages.button';
+
+const lot = { id: 'lot-1', name: 'Watch' } as any;
 
 describe('ManageLotImagesButton', () => {
-  it.todo('renders as a disabled button when disabled prop is true');
-  it.todo('renders as an enabled button when disabled prop is false');
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders as a disabled button when disabled prop is true', () => {
+    render(<ManageLotImagesButton lot={lot} auctionId="auction-1" disabled={true} />);
+
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('renders as an enabled button when disabled prop is false', () => {
+    render(<ManageLotImagesButton lot={lot} auctionId="auction-1" disabled={false} />);
+
+    expect(screen.getByRole('button')).not.toBeDisabled();
+  });
 });

--- a/client/app/crm/auctions/[auctionId]/ManageLotImages.button.test.tsx
+++ b/client/app/crm/auctions/[auctionId]/ManageLotImages.button.test.tsx
@@ -1,0 +1,7 @@
+// @vitest-environment jsdom
+import { describe, it } from 'vitest';
+
+describe('ManageLotImagesButton', () => {
+  it.todo('renders as a disabled button when disabled prop is true');
+  it.todo('renders as an enabled button when disabled prop is false');
+});

--- a/client/app/crm/auctions/[auctionId]/ManageLotImages.button.tsx
+++ b/client/app/crm/auctions/[auctionId]/ManageLotImages.button.tsx
@@ -11,9 +11,10 @@ import { useErrorNotification } from '@/src/modules/notifications/NotifcationCon
 type Props = {
   lot: Lot;
   auctionId: Auction['id'];
+  disabled?: boolean;
 };
 
-const ManageLotImagesButton = ({ lot, auctionId }: Props) => {
+const ManageLotImagesButton = ({ lot, auctionId, disabled }: Props) => {
   const handleError = useErrorNotification();
   const router = useRouter();
 
@@ -28,7 +29,7 @@ const ManageLotImagesButton = ({ lot, auctionId }: Props) => {
   };
 
   return (
-    <Button variant="ghost" size="icon" onClick={handleClick} title={`Manage ${lot.name} images`}>
+    <Button variant="ghost" size="icon" onClick={handleClick} title={`Manage ${lot.name} images`} disabled={disabled}>
       <Images />
     </Button>
   );

--- a/client/app/crm/auctions/[auctionId]/page.test.tsx
+++ b/client/app/crm/auctions/[auctionId]/page.test.tsx
@@ -1,0 +1,10 @@
+import { describe, it } from 'vitest';
+
+describe('AuctionPage', () => {
+  it.todo('renders status badge for CREATED status');
+  it.todo('renders status badge for STARTED status');
+  it.todo('renders status badge for FINISHED status');
+  it.todo('shows finishedAt date when status is FINISHED');
+  it.todo('hides finishedAt date when status is CREATED');
+  it.todo('hides finishedAt date when status is STARTED');
+});

--- a/client/app/crm/auctions/[auctionId]/page.test.tsx
+++ b/client/app/crm/auctions/[auctionId]/page.test.tsx
@@ -1,10 +1,97 @@
-import { describe, it } from 'vitest';
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AuctionStatus } from '@/src/api/dto/auction.dto';
+
+const { mockFetchAuction } = vi.hoisted(() => ({
+  mockFetchAuction: vi.fn(),
+}));
+
+vi.mock('@/src/api/auctions-api/requests/auctions', () => ({
+  fetchAuctionByIdServer: mockFetchAuction,
+}));
+
+vi.mock('@/app/crm/auctions/[auctionId]/LotsList.table', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/app/crm/auctions/[auctionId]/StartAuction.button', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/app/crm/auctions/[auctionId]/ResetAuction.button', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/app/crm/auctions/[auctionId]/CreateLot.button', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/src/layouts/CrmHeader', () => ({
+  default: () => null,
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children }: any) => <>{children}</>,
+}));
+
+import AuctionPage from './page';
+
+const makeAuction = (status: AuctionStatus, finishedAt: string | null = null) => ({
+  id: 'auction-1',
+  name: 'Test Auction',
+  description: null,
+  status,
+  createdAt: '2025-01-01T10:00:00Z',
+  finishedAt,
+});
+
+const params = (auctionId = 'auction-1') => Promise.resolve({ auctionId });
 
 describe('AuctionPage', () => {
-  it.todo('renders status badge for CREATED status');
-  it.todo('renders status badge for STARTED status');
-  it.todo('renders status badge for FINISHED status');
-  it.todo('shows finishedAt date when status is FINISHED');
-  it.todo('hides finishedAt date when status is CREATED');
-  it.todo('hides finishedAt date when status is STARTED');
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders status badge for CREATED status', async () => {
+    mockFetchAuction.mockResolvedValue(makeAuction(AuctionStatus.CREATED));
+    render(await AuctionPage({ params: params() }));
+
+    expect(screen.getByText(AuctionStatus.CREATED)).toBeInTheDocument();
+  });
+
+  it('renders status badge for STARTED status', async () => {
+    mockFetchAuction.mockResolvedValue(makeAuction(AuctionStatus.STARTED));
+    render(await AuctionPage({ params: params() }));
+
+    expect(screen.getByText(AuctionStatus.STARTED)).toBeInTheDocument();
+  });
+
+  it('renders status badge for FINISHED status', async () => {
+    mockFetchAuction.mockResolvedValue(makeAuction(AuctionStatus.FINISHED, '2025-06-01T18:00:00Z'));
+    render(await AuctionPage({ params: params() }));
+
+    expect(screen.getByText(AuctionStatus.FINISHED)).toBeInTheDocument();
+  });
+
+  it('shows finishedAt date when status is FINISHED', async () => {
+    mockFetchAuction.mockResolvedValue(makeAuction(AuctionStatus.FINISHED, '2025-06-01T18:00:00Z'));
+    render(await AuctionPage({ params: params() }));
+
+    expect(screen.getByText(/finished at/i)).toBeInTheDocument();
+  });
+
+  it('hides finishedAt date when status is CREATED', async () => {
+    mockFetchAuction.mockResolvedValue(makeAuction(AuctionStatus.CREATED));
+    render(await AuctionPage({ params: params() }));
+
+    expect(screen.queryByText(/finished at/i)).not.toBeInTheDocument();
+  });
+
+  it('hides finishedAt date when status is STARTED', async () => {
+    mockFetchAuction.mockResolvedValue(makeAuction(AuctionStatus.STARTED));
+    render(await AuctionPage({ params: params() }));
+
+    expect(screen.queryByText(/finished at/i)).not.toBeInTheDocument();
+  });
 });

--- a/client/app/crm/auctions/[auctionId]/page.tsx
+++ b/client/app/crm/auctions/[auctionId]/page.tsx
@@ -3,6 +3,7 @@ import CreateLotButton from '@/app/crm/auctions/[auctionId]/CreateLot.button';
 import LotsList from '@/app/crm/auctions/[auctionId]/LotsList.table';
 import StartAuctionButton from '@/app/crm/auctions/[auctionId]/StartAuction.button';
 import ResetAuctionButton from '@/app/crm/auctions/[auctionId]/ResetAuction.button';
+import AuctionStatusBadge from '@/app/crm/auctions/Auction.status';
 import { fetchAuctionByIdServer } from '@/src/api/auctions-api/requests/auctions';
 import { AuctionStatus } from '@/src/api/dto/auction.dto';
 import { Card, CardHeader, CardTitle, CardContent, CardDescription } from '@/ui-kit/ui/card';
@@ -21,12 +22,16 @@ const AuctionPage = async ({ params }: LotsPageProps) => {
   const { auctionId } = await params;
 
   const auction = await fetchAuctionByIdServer(auctionId);
+  const isLocked = auction.status !== AuctionStatus.CREATED;
 
   return (
     <div className="space-y-8 p-8">
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0">
-          <CardTitle className="text-3xl">{auction.name}</CardTitle>
+          <div className="flex items-center gap-3">
+            <CardTitle className="text-3xl">{auction.name}</CardTitle>
+            <AuctionStatusBadge status={auction.status} />
+          </div>
 
           <div className="flex items-center gap-2">
             {auction.status === AuctionStatus.FINISHED && (
@@ -56,16 +61,19 @@ const AuctionPage = async ({ params }: LotsPageProps) => {
 
           <div className="text-sm text-muted-foreground">
             <p>Created at: {formatISODate(auction.createdAt)}</p>
+            {auction.status === AuctionStatus.FINISHED && auction.finishedAt && (
+              <p>Finished at: {formatISODate(auction.finishedAt)}</p>
+            )}
             <p>ID: {auction.id}</p>
           </div>
         </CardContent>
       </Card>
 
       <div className="pl-6 pr-6">
-        <CrmHeader title="Lots" action={<CreateLotButton auctionId={auction.id} />} />
+        <CrmHeader title="Lots" action={<CreateLotButton auctionId={auction.id} disabled={isLocked} />} />
       </div>
 
-      <LotsList auctionId={auction.id} />
+      <LotsList auctionId={auction.id} isLocked={isLocked} />
     </div>
   );
 };

--- a/client/src/api/dto/auction.dto.ts
+++ b/client/src/api/dto/auction.dto.ts
@@ -10,6 +10,7 @@ export type Auction = {
   description?: string;
   status: AuctionStatus;
   createdAt: string;
+  finishedAt: string | null;
 };
 
 export type CreateAuctionDto = Pick<Auction, 'name' | 'description'>;

--- a/docs/features/FEAT-004-auction-status-and-edit-guards/04-tasks/T-001-status-finishedat-display.md
+++ b/docs/features/FEAT-004-auction-status-and-edit-guards/04-tasks/T-001-status-finishedat-display.md
@@ -1,0 +1,86 @@
+# Task T-001: Show Status and finishedAt on Auction Detail Page
+
+**Task ID:** T-001
+**Feature:** FEAT-004-auction-status-and-edit-guards
+**Status:** Todo
+**Priority:** Must-have
+**Depends on:** none
+
+---
+
+## 1. Context
+
+The `/crm/auctions/[auctionId]` detail page currently renders auction metadata (name,
+description, createdAt) and lifecycle buttons but shows no status badge. The server
+entity carries a `finishedAt` timestamp that is set when an auction is finished, but
+this field is never surfaced in the `AuctionDto` or the client type, so the UI cannot
+display it.
+
+This task covers the full data + display slice: expose the field from the server, add it
+to the client type, then render both the status badge and the finishedAt date on the
+detail page. It is a prerequisite for T-003, which uses the auction status on the same
+page to control button states.
+
+Related requirements: REQ-1 (status display), REQ-2 (finishedAt display)
+
+## 2. Description
+
+Add `finishedAt` to the server `AuctionDto` and mirror it in the client `Auction` type.
+On the detail page, render the existing `<AuctionStatus>` badge (already used on the
+auctions list page) and, when the auction is FINISHED, display the formatted `finishedAt`
+date alongside it.
+
+## 3. Files to Touch
+
+**Modify:**
+- `server/src/modules/auctions/dto/auction.dto.ts` — add `finishedAt: Date | null` to `AuctionDto`
+- `client/src/api/dto/auction.dto.ts` — add `finishedAt: string | null` to `Auction` type
+- `client/app/crm/auctions/[auctionId]/page.tsx` — render status badge and conditional finishedAt
+
+**Read for context (no changes expected):**
+- `server/src/modules/auctions/entities/auction.entity.ts` — field definition reference
+- `client/app/crm/auctions/Auction.status.tsx` — existing badge component to import
+
+## 4. Implementation Plan
+
+1. In `server/src/modules/auctions/dto/auction.dto.ts`, add `finishedAt: Date | null` to the `AuctionDto` class. Ensure the field is included when mapping the entity to the DTO in `auctions.service.ts` (check the mapper/select statement).
+2. In `client/src/api/dto/auction.dto.ts`, add `finishedAt: string | null` to the `Auction` type.
+3. In `client/app/crm/auctions/[auctionId]/page.tsx`, import `AuctionStatus` from `../Auction.status.tsx` and render it next to or below the auction name.
+4. Below the status badge, conditionally render the `finishedAt` date (formatted with `toLocaleDateString` or similar) only when `auction.status === AuctionStatus.FINISHED`.
+
+## 5. Definition of Done
+
+- [ ] All code lints cleanly.
+- [ ] Test files exist (scaffolded).
+- [ ] No regressions in existing tests.
+- [ ] Code follows existing project conventions.
+- [ ] `AuctionDto` on the server includes `finishedAt` (null for non-finished auctions).
+- [ ] Client `Auction` type includes `finishedAt: string | null`.
+- [ ] Status badge renders on the detail page for all three auction statuses.
+- [ ] `finishedAt` date is visible on the detail page only when status is `FINISHED`.
+
+## 6. Test Plan
+
+**Unit tests (Vitest):**
+- `auctions.service.ts` — `findOne` returns an auction with `finishedAt` populated when status is `FINISHED`; returns `null` for `finishedAt` when status is `CREATED`
+
+**Component tests (RTL):**
+- `page.tsx` renders the status badge for each `AuctionStatus` value
+- `page.tsx` shows the `finishedAt` date when status is `FINISHED` and hides it otherwise
+
+**E2E tests (Playwright):**
+- None required for this task (covered by T-003 e2e flow).
+
+**Test data needs:**
+- Fixture auction objects for each status: `CREATED` (no finishedAt), `STARTED` (no finishedAt), `FINISHED` (finishedAt set)
+
+## 7. Notes & Considerations
+
+- The `AuctionStatus` badge component at `client/app/crm/auctions/Auction.status.tsx` already handles all three statuses — just import and pass `status`.
+- The server `auctions.service.ts` mapper/select may need to explicitly include `finishedAt` if it is using a column selection — check whether the field is already fetched from the DB.
+- No migration is needed: `finishedAt` already exists on the entity and DB column.
+
+## 8. References
+
+- Feature: FEAT-004-auction-status-and-edit-guards
+- Related tasks: T-003 (consumes auction status from this task's detail page changes)

--- a/docs/features/FEAT-004-auction-status-and-edit-guards/04-tasks/T-002-backend-edit-guard.md
+++ b/docs/features/FEAT-004-auction-status-and-edit-guards/04-tasks/T-002-backend-edit-guard.md
@@ -1,0 +1,88 @@
+# Task T-002: Backend Guard — Reject Edits When Auction Is Started
+
+**Task ID:** T-002
+**Feature:** FEAT-004-auction-status-and-edit-guards
+**Status:** Todo
+**Priority:** Must-have
+**Depends on:** none
+
+---
+
+## 1. Context
+
+The backend exposes `PATCH /auctions/:id` and `PATCH /auctions/:auctionId/lots/:lotId`
+endpoints, as well as lot image upload/delete routes. Currently none of these check
+whether the auction is in a mutable state before applying changes — an admin could
+edit auction details or lot data even mid-auction, which would corrupt in-progress state.
+
+This task adds a status guard at the service layer so that any mutation on an auction
+(or its lots) that arrives when the auction is `STARTED` or `FINISHED` is rejected with
+a `400 Bad Request`.
+
+Related requirements: REQ-3 (backend guard for edit operations)
+
+## 2. Description
+
+Add an auction-state check to `auctions.service.ts#updateOne` and to the relevant lot
+mutation methods in `lots.service.ts`. When the auction status is not `CREATED`, throw
+a `BadRequestException` with a clear message before any write operation is performed.
+The guard lives at the service layer so it applies regardless of which controller or
+future integration path calls these methods.
+
+## 3. Files to Touch
+
+**Modify:**
+- `server/src/modules/auctions/auctions.service.ts` — add status check at the start of `updateOne`
+- `server/src/modules/lots/lots.service.ts` — add auction status check in `updateLot` and lot image operations
+
+**Read for context (no changes expected):**
+- `server/src/modules/auctions/entities/auction.entity.ts` — `AuctionStatus` enum
+- `server/src/modules/lots/lots.controller.ts` — route surface to confirm which operations need guarding
+- `server/src/modules/room/room.service.ts` — reference for how existing state guards are phrased
+
+## 4. Implementation Plan
+
+1. In `auctions.service.ts#updateOne`, immediately after loading the existing auction (before the `preload`/`save` call), check `if (auction.status !== AuctionStatus.CREATED)` and throw `new BadRequestException('Auction cannot be edited after it has started')`.
+2. In `lots.service.ts`, identify all methods that write to a lot: `updateLot` and any image upload/delete helpers. For each, fetch the parent auction status (either via `AuctionsService.findOne` or a direct repository call using `auctionId`). Throw `new BadRequestException('Auction cannot be edited after it has started')` if status is not `CREATED`.
+3. Ensure no circular dependency is introduced if `LotsService` references `AuctionsService` — use the existing repository or inject `AuctionsService` via `forwardRef` if needed.
+4. Verify the error message is consistent across both services.
+
+## 5. Definition of Done
+
+- [ ] All code lints cleanly.
+- [ ] Test files exist (scaffolded).
+- [ ] No regressions in existing tests.
+- [ ] Code follows existing project conventions.
+- [ ] `PATCH /auctions/:id` returns `400` when auction status is `STARTED` or `FINISHED`.
+- [ ] `PATCH /auctions/:auctionId/lots/:lotId` returns `400` when auction status is `STARTED` or `FINISHED`.
+- [ ] Lot image upload/delete operations return `400` under the same condition.
+- [ ] All three endpoints remain fully functional for `CREATED` auctions.
+- [ ] Error response body contains a clear, human-readable message.
+
+## 6. Test Plan
+
+**Unit tests (Vitest):**
+- `auctions.service.ts#updateOne` — throws `BadRequestException` when auction is `STARTED`; throws when `FINISHED`; succeeds when `CREATED`
+- `lots.service.ts#updateLot` — throws `BadRequestException` when parent auction is `STARTED` or `FINISHED`; succeeds when `CREATED`
+
+**Component tests (RTL):**
+- None (backend-only task).
+
+**E2E tests (Playwright):**
+- None required (unit coverage sufficient for guard logic).
+
+**Test data needs:**
+- Mock auction entities in each status for service unit tests
+
+## 7. Notes & Considerations
+
+- `room.service.ts` already has examples of status guards (`finishAuction`, `resetAuction`) — follow the same `BadRequestException` pattern for consistency.
+- The `lots.service.ts` currently calls `this.findLot(userId, auctionId, lotId)` which loads the lot. The auction status is not yet fetched there — you'll need an additional load or join.
+- If `LotsService` does not already inject `AuctionsService`, check for circular dependency risk before injecting. An alternative is a direct `auctionsRepository` query for just the status field to keep it lightweight.
+- Do not add the guard to state-transition methods (`startAuction`, `finishAuction`, `resetAuction`) — those are already protected by `RoomService` logic.
+
+## 8. References
+
+- Feature: FEAT-004-auction-status-and-edit-guards
+- Related tasks: T-003 (frontend complement to this guard)
+- Pattern reference: `server/src/modules/room/room.service.ts` — `finishAuction` and `resetAuction` status checks

--- a/docs/features/FEAT-004-auction-status-and-edit-guards/04-tasks/T-003-disable-lot-mutation-buttons.md
+++ b/docs/features/FEAT-004-auction-status-and-edit-guards/04-tasks/T-003-disable-lot-mutation-buttons.md
@@ -1,0 +1,93 @@
+# Task T-003: Disable Lot Mutation Buttons When Auction Is Started
+
+**Task ID:** T-003
+**Feature:** FEAT-004-auction-status-and-edit-guards
+**Status:** Todo
+**Priority:** Must-have
+**Depends on:** T-001
+
+---
+
+## 1. Context
+
+The `/crm/auctions/[auctionId]` detail page lets admins create lots, delete lots, and
+manage lot images. Once an auction is started, none of these mutations should be
+permitted — the backend (T-002) enforces this at the API layer, but the UI should
+reflect the locked state proactively to prevent confusing error flows.
+
+This task wires the auction status (already visible on the page after T-001) into the
+three mutation button components so they become visually disabled when the auction is
+`STARTED` or `FINISHED`. It depends on T-001 because both tasks modify `page.tsx` and
+T-001's changes must land first to avoid a merge conflict.
+
+Related requirements: REQ-3 (frontend disable for lot mutations)
+
+## 2. Description
+
+Compute a boolean `isLocked` flag from the auction status in `page.tsx` and pass it as
+a prop to `CreateLotButton`, `DeleteLotButton`, and `ManageLotImagesButton`. Each button
+component should render its underlying `<Button>` as `disabled` when `isLocked` is
+`true`. Buttons stay rendered (not conditionally removed) so the page layout does not
+shift.
+
+## 3. Files to Touch
+
+**Modify:**
+- `client/app/crm/auctions/[auctionId]/page.tsx` — compute `isLocked`, pass as prop to the three buttons
+- `client/app/crm/auctions/[auctionId]/CreateLot.button.tsx` — accept `disabled` prop and apply it
+- `client/app/crm/auctions/[auctionId]/DeleteLot.button.tsx` — accept `disabled` prop and apply it
+- `client/app/crm/auctions/[auctionId]/ManageLotImages.button.tsx` — accept `disabled` prop and apply it
+
+**Read for context (no changes expected):**
+- `client/src/api/dto/auction.dto.ts` — `AuctionStatus` enum values
+- `client/app/crm/auctions/[auctionId]/StartAuction.button.tsx` — reference for existing button prop patterns
+
+## 4. Implementation Plan
+
+1. In `page.tsx`, after the auction fetch, compute:
+   ```ts
+   const isLocked = auction.status !== AuctionStatus.CREATED;
+   ```
+   Pass `isLocked` as a prop to `<CreateLotButton>`, `<DeleteLotButton>`, and `<ManageLotImagesButton>`.
+2. In `CreateLot.button.tsx`, add `disabled?: boolean` to the component props interface and wire it to the `<Button disabled={disabled}>` (or the trigger of the confirmation modal).
+3. In `DeleteLot.button.tsx`, add `disabled?: boolean` and apply it similarly. The button should be disabled before any confirmation modal opens, so the modal itself never fires when locked.
+4. In `ManageLotImages.button.tsx`, apply the same `disabled` pattern.
+5. Verify that the `disabled` shadcn/ui `<Button>` renders with correct visual treatment (muted/opacity) — no custom CSS needed; shadcn handles this via the `disabled` attribute.
+
+## 5. Definition of Done
+
+- [ ] All code lints cleanly.
+- [ ] Test files exist (scaffolded).
+- [ ] No regressions in existing tests.
+- [ ] Code follows existing project conventions.
+- [ ] All three mutation buttons are visually disabled when auction status is `STARTED` or `FINISHED`.
+- [ ] All three mutation buttons are fully active when auction status is `CREATED`.
+- [ ] Buttons remain rendered in both states (no conditional mount/unmount).
+- [ ] No confirmation modals open when a button is in the disabled state.
+
+## 6. Test Plan
+
+**Unit tests (Vitest):**
+- None (no pure logic to isolate).
+
+**Component tests (RTL):**
+- `CreateLot.button.tsx` — renders a disabled `<button>` element when `disabled={true}`; renders an enabled `<button>` when `disabled={false}`
+- `DeleteLot.button.tsx` — same disabled/enabled assertions
+- `ManageLotImages.button.tsx` — same disabled/enabled assertions
+
+**E2E tests (Playwright):**
+- Happy path: navigate to a started auction's detail page, assert CreateLot button is disabled, assert ManageLotImages button is disabled
+
+**Test data needs:**
+- Auction fixture with status `STARTED` for component and e2e tests
+
+## 7. Notes & Considerations
+
+- `StartAuction.button.tsx` can serve as a reference for how existing button components handle conditional rendering and prop patterns in this directory.
+- shadcn/ui `<Button>` passes the `disabled` HTML attribute through by default — no custom styling needed.
+- If any button component uses a separate trigger element (e.g. inside a `<Dialog>` or `<AlertDialog>`), apply `disabled` on the trigger, not the dialog's action button, so the modal never opens.
+
+## 8. References
+
+- Feature: FEAT-004-auction-status-and-edit-guards
+- Related tasks: T-001 (prerequisite — modifies `page.tsx` first), T-002 (backend complement)

--- a/docs/features/FEAT-004-auction-status-and-edit-guards/05-review-FEAT-004.md
+++ b/docs/features/FEAT-004-auction-status-and-edit-guards/05-review-FEAT-004.md
@@ -1,0 +1,166 @@
+# Code Review — FEAT-004: Auction Status Guards and Lot Mutation Lock
+
+**Feature:** FEAT-004-auction-status-and-edit-guards
+**Tasks:** T-001, T-002, T-003 (combined — all in one commit)
+**Reviewer:** sdlc-review (inline)
+**Diff base:** `main..working-tree` (committed `b1dc41b` + in-progress unstaged refactoring)
+**Diff scope:** 19 files committed (+368 / -23 lines); 5 server files unstaged (+217 / -41 lines)
+**Date:** 2026-05-18
+
+> **Note on diff base:** The committed changes (`b1dc41b`) represent the bulk of the feature. Five server files have unstaged changes that refactor the guard (moving `assertAuctionEditable` from `lots.service.ts` to a new `checkEditableStatus` in `auctions.service.ts`) and fill the test scaffolds. This review covers the full working-tree state — the combined intent of the branch.
+
+---
+
+## Summary
+
+Request changes — 4 Significant findings, 2 Nits. The T-001 and T-003 implementations are clean and satisfy their DoD items completely. T-002's functional requirements are also met (all three endpoint types return 400 for non-CREATED auctions), but the refactoring in-progress introduces two concerns: the guard was moved from the service layer to the controller layer (directly contradicting T-002's stated architectural principle), and the `POST /lots` create endpoint remains unguarded at the backend while the frontend disables the button. Additionally, every guarded mutation now triggers two sequential auction fetches, and the controller-level guard integration has no test coverage.
+
+**Verdict:** Request changes
+
+**Counts:** Blocking: 0 · Significant: 4 · Nits: 2
+
+---
+
+## Definition-of-Done check
+
+### T-001
+
+- [x] `AuctionDto` on the server includes `finishedAt` (null for non-finished) — `server/src/modules/auctions/dto/auction.dto.ts:25`
+- [x] Client `Auction` type includes `finishedAt: string | null` — `client/src/api/dto/auction.dto.ts:13`
+- [x] Status badge renders on detail page — `client/app/crm/auctions/[auctionId]/page.tsx:33`
+- [x] `finishedAt` visible only when status is `FINISHED` — `page.tsx:64-66`
+- [x] Test scaffolds exist — `page.test.tsx`, `auctions.service.spec.ts` `findOne` describe block
+- [x] All code lints cleanly — no evidence of violations
+- [x] No regressions in existing tests — guard tests are additive
+- [x] Code follows existing project conventions — ✅
+
+### T-002
+
+- [x] `PATCH /auctions/:id` returns 400 when started/finished — inline check in `auctions.service.ts:117-119`
+- [x] `PATCH /auctions/:auctionId/lots/:lotId` returns 400 — controller calls `checkEditableStatus` at `lots.controller.ts:89`
+- [x] Image upload/delete return 400 — controller calls `checkEditableStatus` at `lots.controller.ts:114,127,141`
+- [~] Guard lives at the service layer — **partial**: see S-1. The in-progress refactoring moves the guard to the controller; `lots.service.ts` no longer contains the check.
+- [~] Test coverage for `updateLot` guard behavior — **partial**: see S-4. Guard is tested in `auctions.service.spec.ts` but no integration test verifies the controller calls it or that the rejection propagates.
+- [x] All three endpoints functional for `CREATED` auctions — logic is correct
+- [x] Error message is clear and consistent — `'Auction cannot be edited after it has started'`
+
+### T-003
+
+- [x] All three mutation buttons disabled when locked — `CreateLot.button.tsx:43`, `DeleteLot.button.tsx:50`, `ManageLotImages.button.tsx:32`
+- [x] Buttons remain rendered in both states (no conditional mount) — ✅
+- [x] No confirmation modal opens when disabled — `disabled` on `<Button>` blocks click events before handlers fire
+- [x] Test scaffolds exist — `CreateLot.button.test.tsx`, `DeleteLot.button.test.tsx`, `ManageLotImages.button.test.tsx`
+
+---
+
+## Files-to-Touch contract check
+
+| Path | In contract? | In diff? | Notes |
+|---|---|---|---|
+| `server/src/modules/auctions/dto/auction.dto.ts` | T-001 Modify | Yes | OK |
+| `client/src/api/dto/auction.dto.ts` | T-001 Modify | Yes | OK |
+| `client/app/crm/auctions/[auctionId]/page.tsx` | T-001 + T-003 Modify | Yes | OK |
+| `server/src/modules/auctions/auctions.service.ts` | T-002 Modify | Yes (unstaged) | OK |
+| `server/src/modules/lots/lots.service.ts` | T-002 Modify | Yes | OK |
+| `client/app/crm/auctions/[auctionId]/CreateLot.button.tsx` | T-003 Modify | Yes | OK |
+| `client/app/crm/auctions/[auctionId]/DeleteLot.button.tsx` | T-003 Modify | Yes | OK |
+| `client/app/crm/auctions/[auctionId]/ManageLotImages.button.tsx` | T-003 Modify | Yes | OK |
+| `client/app/crm/auctions/[auctionId]/LotsList.table.tsx` | T-003 implied | Yes | isLocked prop pass-through — reasonable extension |
+| `server/src/modules/lots/lots.controller.ts` | T-002 "Read for context" | Yes (both committed + unstaged) | Out-of-contract modification — see S-1 for why this matters |
+| Test scaffold files (*.test.tsx, *.spec.ts) | All tasks — "Test files exist" DoD | Yes | Expected |
+
+---
+
+## Findings
+
+### Significant
+
+#### S-1 — Guard refactored to controller layer, violating T-002's explicit architectural principle
+**Where:** `server/src/modules/lots/lots.controller.ts:89,114,127,141` (unstaged state)
+**What:** The in-progress unstaged refactoring removes `assertAuctionEditable()` from `lots.service.ts` and introduces `checkEditableStatus()` in `auctions.service.ts`, called from the controller before each mutating handler. This means `lotsService.updateLot()`, `createPresignedUrls()`, `addImages()`, and `removeImage()` contain no status guard. Any caller that bypasses the controller (a WebSocket handler, another service, a future admin task) can freely mutate lots on a started or finished auction.
+**Why Significant:** T-002 Notes explicitly state: _"The guard lives at the service layer so it applies regardless of which controller or future integration path calls these methods."_ `lots.controller.ts` is also listed under "Read for context (no changes expected)" — it is an out-of-contract file. The functional DoD checklist items are satisfied, but the stated design rationale is not.
+**Suggested fix:** Reinstate the status check inside the relevant `lots.service.ts` methods. The cleanest option is to call `this.auctionsService.checkEditableStatus(userId, auctionId)` at the top of `updateLot`, `createPresignedUrls`, `addImages`, and `removeImage`. The controller does not need its own pre-call — it can trust the service.
+
+---
+
+#### S-2 — `POST /auctions/:auctionId/lots` (create lot) is unguarded at the backend
+**Where:** `server/src/modules/lots/lots.controller.ts:41-48`, `server/src/modules/lots/lots.service.ts:63-79`
+**What:** The create-lot endpoint has no `checkEditableStatus` call — neither in the controller handler nor inside `lotsService.createLots()`. A direct API call can create lots on a `STARTED` or `FINISHED` auction, bypassing the frontend button lock added by T-003. `DELETE /lots/:lotId` is intentionally unguarded (lots may be deleted mid-auction by design).
+**Why Significant:** T-003 disables the Create Lot button for non-CREATED auctions — the frontend and backend are asymmetric. Without a backend guard, the frontend protection is bypassable by any HTTP client. Though not in T-002's explicit DoD checklist, it is an implied consequence of the feature's stated goal: "corrupted in-progress state" (T-002 §1).
+**Suggested fix:** Add `await this.auctionsService.checkEditableStatus(userId, auctionId)` as the first line of `lotsService.createLots()` (per S-1's recommendation of service-layer placement). Add unit tests covering `BadRequestException` when auction status is `STARTED` or `FINISHED`.
+
+---
+
+#### S-3 — Every guarded lot mutation triggers two sequential auction fetches
+**Where:** `server/src/modules/lots/lots.controller.ts:89` → `auctions.service.ts:83` then `lots.service.ts:48-50`
+**What:** The controller calls `checkEditableStatus(userId, auctionId)` which internally calls `findOne()` — one DB round-trip for the auction. Each subsequent service method (e.g. `updateLot`) calls `findLot()` → `findAuction()` → `auctionsService.findOne()` — a second DB round-trip for the same auction. Every guarded mutation hits the auction table twice. The same pattern exists for `createPresignedUrls`, `addImages`, and `removeImage` in their controller-call path.
+**Why Significant:** The double-fetch is unnecessary latency on every write path. It also creates a TOCTOU window: the auction status could change between the guard fetch and the operation fetch (unlikely in practice but architecturally unsound).
+**Suggested fix:** (a) Have `checkEditableStatus` return the fetched `Auction` entity and pass it into the service method, avoiding the second lookup. Or (b) add a `findAuctionEditable(userId, auctionId)` helper in `AuctionsService` that checks ownership and status in one query and returns the entity, replacing both `findOne` calls. Per S-1's fix, if the guard moves back to the service, the service can do a single fetch that handles both ownership and status in `findLot`'s already-loaded auction context.
+
+---
+
+#### S-4 — Controller-level guard integration has no test coverage
+**Where:** `server/src/modules/lots/lots.service.spec.ts` (82 lines total)
+**What:** T-002's test plan specifies: _"lots.service.ts#updateLot — throws `BadRequestException` when parent auction is `STARTED` or `FINISHED`; succeeds when `CREATED`."_ The guard was moved to the controller, so these service-layer tests were never written and no controller-level tests were added to replace them. `lots.service.spec.ts` only covers `updateLot` success and `NotFoundException`. `checkEditableStatus` is tested in isolation in `auctions.service.spec.ts` (lines 320-359), but the integration — controller calling it, rejection propagating to the HTTP response — is untested. There are also no tests for S-2's gap (create lot with non-CREATED auction).
+**Why Significant:** The guard behavior for lot mutations is the core correctness claim of T-002. An untested guard that gets silently removed or bypassed in a future refactor would not be caught.
+**Suggested fix:** If the guard moves to the service (S-1), add guard tests directly to `lots.service.spec.ts` for `updateLot`, `createLots`, `createPresignedUrls`, `addImages`, and `removeImage`. Each needs two cases: throws `BadRequestException` when `STARTED`, throws when `FINISHED`. The `AuctionsService` mock in `lots.service.spec.ts` currently only mocks `findOne` — also mock `checkEditableStatus` (or configure `findOne` to return the appropriate status). If the guard stays in the controller, add `lots.controller.spec.ts`.
+
+---
+
+### Nits
+
+#### N-1 — Stale `RoomRepository` provider in `auctions.service.spec.ts`
+**Where:** `server/src/modules/auctions/auctions.service.spec.ts:71`
+**What:** `RoomRepository` is registered as a provider in the test module but `AuctionsService` does not inject it. A comment at lines 141–144 acknowledges this explicitly. The dead provider is harmless but adds confusion when reading or extending the test.
+**Suggested fix:** Remove the `{ provide: RoomRepository, useValue: { clearRoom: jest.fn() } }` block and the `RoomRepository` import at line 10.
+
+---
+
+#### N-2 — Stale `preload` mock in the auction repository mock
+**Where:** `server/src/modules/auctions/auctions.service.spec.ts:63`
+**What:** The repository mock includes `preload: jest.fn()` but this diff replaced the `preload` call in `auctions.service.ts#updateOne` with a direct `findOne` call. The mock method is never invoked and its presence implies `preload` is still used.
+**Suggested fix:** Remove the `preload: jest.fn()` entry from the repository mock object.
+
+---
+
+## Alignment with task files
+
+No ADR or Feature Spec exists for FEAT-004. Alignment is checked against the three task files only.
+
+- ✅ T-001 implementation plan followed step-by-step (DTO → client type → badge → finishedAt conditional).
+- ✅ T-001 reference to `Auction.status.tsx` badge used correctly — imported and rendered.
+- ⚠️ T-002 implementation plan says guard in `lots.service.ts` (S-1). Controller is listed as read-only context.
+- ⚠️ T-002 test plan specifies `lots.service.ts#updateLot` guard tests — not written (S-4).
+- ✅ T-003 `isLocked` computed as `auction.status !== AuctionStatus.CREATED` — matches plan exactly.
+- ✅ T-003 `disabled` prop wired to shadcn `<Button disabled>` on all three components — no custom CSS, correct.
+- ✅ T-003 buttons stay rendered in both states — confirmed, no conditional mount/unmount.
+
+---
+
+## Test scaffold coverage
+
+| Scaffold file | Task Plan entry | Shape |
+|---|---|---|
+| `page.test.tsx` (6 `.todo()`) | T-001: page renders status badge for each status; hides/shows finishedAt | Correct placeholder; needs RTL fill |
+| `CreateLot.button.test.tsx` (2 `.todo()`) | T-003: disabled/enabled assertions | Correct placeholder |
+| `DeleteLot.button.test.tsx` (2 `.todo()`) | T-003: disabled/enabled assertions | Correct placeholder |
+| `ManageLotImages.button.test.tsx` (2 `.todo()`) | T-003: disabled/enabled assertions | Correct placeholder |
+| `auctions.service.spec.ts` — `findOne` describe | T-001: finishedAt cases | Filled (unstaged) — correct |
+| `auctions.service.spec.ts` — `updateOne` describe | T-002: guard cases | Filled (unstaged) — correct |
+| `auctions.service.spec.ts` — `checkEditableStatus` describe | T-002: guard unit test | Filled (unstaged) — correct |
+| `lots.service.spec.ts` — `updateLot` describe | T-002: guard for updateLot | Missing guard cases — see S-4 |
+
+---
+
+## Open questions for the user
+
+- **Q1:** Is the guard-at-controller pattern (S-1) a deliberate departure from T-002, or is the plan still to move it back to the service before the PR lands? If controller-layer is the final intent, T-002 Notes should be updated to reflect the new rationale.
+- **Q2:** For S-3 (double fetch): Is the extra round-trip acceptable given typical auction load, or should it be addressed before merge?
+
+---
+
+## Out of scope for this review
+
+- Deep security audit (OWASP pass on auth, token validation) → `sdlc-security`.
+- Test logic correctness (filling `.todo()` scaffolds, asserting exact DOM output) → `sdlc-tests`.
+- Diagram updates (no new container or actor was introduced) → not required.

--- a/server/src/modules/auctions/auctions.service.spec.ts
+++ b/server/src/modules/auctions/auctions.service.spec.ts
@@ -230,4 +230,15 @@ describe('AuctionsService', () => {
       expect(result.unsoldCount).toBe(1);
     });
   });
+
+  describe('findOne', () => {
+    it.todo('returns finishedAt when auction status is FINISHED');
+    it.todo('returns null for finishedAt when auction status is CREATED');
+  });
+
+  describe('updateOne', () => {
+    it.todo('throws BadRequestException when auction status is STARTED');
+    it.todo('throws BadRequestException when auction status is FINISHED');
+    it.todo('saves and returns updated auction when status is CREATED');
+  });
 });

--- a/server/src/modules/auctions/auctions.service.spec.ts
+++ b/server/src/modules/auctions/auctions.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { NotFoundException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { getDataSourceToken, getRepositoryToken } from '@nestjs/typeorm';
 import { AuctionsService } from './auctions.service';
 import { Auction, AuctionStatus } from './entities/auction.entity';
@@ -41,6 +41,7 @@ describe('AuctionsService', () => {
   let service: AuctionsService;
   let auctionRepo: any;
   let dataSource: { transaction: jest.Mock };
+  let usersService: any;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -75,6 +76,7 @@ describe('AuctionsService', () => {
     service = module.get(AuctionsService);
     auctionRepo = module.get(getRepositoryToken(Auction));
     dataSource = module.get(getDataSourceToken()) as any;
+    usersService = module.get(UsersService);
   });
 
   describe('resetAuction', () => {
@@ -232,13 +234,109 @@ describe('AuctionsService', () => {
   });
 
   describe('findOne', () => {
-    it.todo('returns finishedAt when auction status is FINISHED');
-    it.todo('returns null for finishedAt when auction status is CREATED');
+    it('returns finishedAt when auction status is FINISHED', async () => {
+      // T-001: finishedAt is passed through from the repo when status is FINISHED
+      usersService.findById.mockResolvedValue({ id: 'user-1' });
+      auctionRepo.findOne.mockResolvedValue({
+        id: 'auction-1',
+        status: AuctionStatus.FINISHED,
+        finishedAt: new Date('2025-01-15'),
+      });
+
+      const result = await service.findOne('user-1', 'auction-1');
+
+      expect(result.finishedAt).toBeInstanceOf(Date);
+    });
+
+    it('returns null for finishedAt when auction status is CREATED', async () => {
+      // T-001: finishedAt is null when status is CREATED
+      usersService.findById.mockResolvedValue({ id: 'user-1' });
+      auctionRepo.findOne.mockResolvedValue({
+        id: 'auction-1',
+        status: AuctionStatus.CREATED,
+        finishedAt: null,
+      });
+
+      const result = await service.findOne('user-1', 'auction-1');
+
+      expect(result.finishedAt).toBeNull();
+    });
   });
 
   describe('updateOne', () => {
-    it.todo('throws BadRequestException when auction status is STARTED');
-    it.todo('throws BadRequestException when auction status is FINISHED');
-    it.todo('saves and returns updated auction when status is CREATED');
+    it('throws BadRequestException when auction status is STARTED', async () => {
+      // T-002 AC: throws BadRequestException when auction status is STARTED
+      usersService.findById.mockResolvedValue({ id: 'user-1' });
+      auctionRepo.findOne.mockResolvedValue({
+        id: 'auction-1',
+        status: AuctionStatus.STARTED,
+      });
+
+      await expect(
+        service.updateOne('user-1', 'auction-1', { name: 'X' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when auction status is FINISHED', async () => {
+      // T-002 AC: throws BadRequestException when auction status is FINISHED
+      usersService.findById.mockResolvedValue({ id: 'user-1' });
+      auctionRepo.findOne.mockResolvedValue({
+        id: 'auction-1',
+        status: AuctionStatus.FINISHED,
+      });
+
+      await expect(
+        service.updateOne('user-1', 'auction-1', { name: 'X' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('saves and returns updated auction when status is CREATED', async () => {
+      // T-002 AC: saves and returns updated auction when status is CREATED
+      usersService.findById.mockResolvedValue({ id: 'user-1' });
+      auctionRepo.findOne.mockResolvedValue({
+        id: 'auction-1',
+        name: 'Old',
+        status: AuctionStatus.CREATED,
+      });
+      auctionRepo.save.mockResolvedValue({
+        id: 'auction-1',
+        name: 'New',
+        status: AuctionStatus.CREATED,
+        owner: { id: 'user-1' },
+      });
+
+      const result = await service.updateOne('user-1', 'auction-1', { name: 'New' });
+
+      expect(auctionRepo.save).toHaveBeenCalledWith({
+        id: 'auction-1',
+        name: 'New',
+        status: AuctionStatus.CREATED,
+      });
+      expect(result.name).toBe('New');
+      expect(result).not.toHaveProperty('owner');
+    });
+  });
+
+  describe('checkEditableStatus', () => {
+    it('throws BadRequestException when auction status is STARTED', () => {
+      // T-002 AC: throws BadRequestException when auction status is STARTED
+      expect(() =>
+        service.checkEditableStatus({ id: 'auction-1', status: AuctionStatus.STARTED } as any),
+      ).toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when auction status is FINISHED', () => {
+      // T-002 AC: throws BadRequestException when auction status is FINISHED
+      expect(() =>
+        service.checkEditableStatus({ id: 'auction-1', status: AuctionStatus.FINISHED } as any),
+      ).toThrow(BadRequestException);
+    });
+
+    it('does not throw when auction status is CREATED', () => {
+      // T-002 AC: does not throw when auction status is CREATED
+      expect(() =>
+        service.checkEditableStatus({ id: 'auction-1', status: AuctionStatus.CREATED } as any),
+      ).not.toThrow();
+    });
   });
 });

--- a/server/src/modules/auctions/auctions.service.ts
+++ b/server/src/modules/auctions/auctions.service.ts
@@ -1,4 +1,8 @@
-import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import {
   UpdateAuctionDto,
   CreateAuctionDto,
@@ -94,6 +98,22 @@ export class AuctionsService {
     return auction;
   }
 
+  async findEditableOne(ownerId: User['id'], id: Auction['id']) {
+    const auction = await this.findOne(ownerId, id);
+
+    this.checkEditableStatus(auction);
+
+    return auction;
+  }
+
+  checkEditableStatus(auction: Auction) {
+    if (auction.status !== AuctionStatus.CREATED) {
+      throw new BadRequestException(
+        'Auction cannot be edited after it has started',
+      );
+    }
+  }
+
   async updateOne(
     ownerId: User['id'],
     id: Auction['id'],
@@ -101,20 +121,26 @@ export class AuctionsService {
   ): Promise<AuctionDto> {
     const owner = await this.findOwner(ownerId);
 
-    const auction = await this.auctionsRepository.findOne({ where: { id, owner } });
+    const auction = await this.auctionsRepository.findOne({
+      where: { id, owner },
+    });
 
     if (!auction) {
       throw new NotFoundException(`Auction with id ${id} not found`);
     }
 
     if (auction.status !== AuctionStatus.CREATED) {
-      throw new BadRequestException('Auction cannot be edited after it has started');
+      throw new BadRequestException(
+        'Auction cannot be edited after it has started',
+      );
     }
 
-    const { owner: aucOwner, ...response } = await this.auctionsRepository.save({
-      ...auction,
-      ...updateAuctionDto,
-    });
+    const { owner: aucOwner, ...response } = await this.auctionsRepository.save(
+      {
+        ...auction,
+        ...updateAuctionDto,
+      },
+    );
 
     return response;
   }

--- a/server/src/modules/auctions/auctions.service.ts
+++ b/server/src/modules/auctions/auctions.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import {
   UpdateAuctionDto,
   CreateAuctionDto,
@@ -101,18 +101,20 @@ export class AuctionsService {
   ): Promise<AuctionDto> {
     const owner = await this.findOwner(ownerId);
 
-    const auction = await this.auctionsRepository.preload({
-      id,
-      owner,
-      ...updateAuctionDto,
-    });
+    const auction = await this.auctionsRepository.findOne({ where: { id, owner } });
 
     if (!auction) {
       throw new NotFoundException(`Auction with id ${id} not found`);
     }
 
-    const { owner: aucOwner, ...response } =
-      await this.auctionsRepository.save(auction);
+    if (auction.status !== AuctionStatus.CREATED) {
+      throw new BadRequestException('Auction cannot be edited after it has started');
+    }
+
+    const { owner: aucOwner, ...response } = await this.auctionsRepository.save({
+      ...auction,
+      ...updateAuctionDto,
+    });
 
     return response;
   }

--- a/server/src/modules/auctions/auctions.service.ts
+++ b/server/src/modules/auctions/auctions.service.ts
@@ -119,21 +119,7 @@ export class AuctionsService {
     id: Auction['id'],
     updateAuctionDto: UpdateAuctionDto,
   ): Promise<AuctionDto> {
-    const owner = await this.findOwner(ownerId);
-
-    const auction = await this.auctionsRepository.findOne({
-      where: { id, owner },
-    });
-
-    if (!auction) {
-      throw new NotFoundException(`Auction with id ${id} not found`);
-    }
-
-    if (auction.status !== AuctionStatus.CREATED) {
-      throw new BadRequestException(
-        'Auction cannot be edited after it has started',
-      );
-    }
+    const auction = await this.findEditableOne(ownerId, id);
 
     const { owner: aucOwner, ...response } = await this.auctionsRepository.save(
       {

--- a/server/src/modules/auctions/dto/auction.dto.ts
+++ b/server/src/modules/auctions/dto/auction.dto.ts
@@ -20,6 +20,9 @@ export class AuctionDto {
 
   @ApiProperty({ example: '2025-09-01T12:00:00Z' })
   createdAt: Date;
+
+  @ApiProperty({ example: '2025-09-01T18:00:00Z', nullable: true })
+  finishedAt: Date | null;
 }
 
 export class CreateAuctionDto extends PickType(AuctionDto, [

--- a/server/src/modules/buyers/buyers.service.ts
+++ b/server/src/modules/buyers/buyers.service.ts
@@ -22,7 +22,7 @@ export class BuyersService {
     lotId: Lot['id'],
     buyer: CreateBuyerDto,
   ): Promise<Buyer> {
-    const lot = await this.lotsService.findLot(userId, auctionId, lotId);
+    const lot = await this.lotsService.findAuctionLot(userId, auctionId, lotId);
 
     return this.buyersRepository.save({
       ...buyer,

--- a/server/src/modules/lots/lots.controller.ts
+++ b/server/src/modules/lots/lots.controller.ts
@@ -10,6 +10,7 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { LotsService } from './lots.service';
+import { AuctionsService } from '../auctions/auctions.service';
 import {
   AddLotImagesDto,
   CreateLotsDto,
@@ -67,7 +68,7 @@ export class LotsController {
     @Param('lotId') lotId: string,
     @AuthUser() user: TokenPayload,
   ): Promise<LotDto> {
-    return this.lotsService.findLot(user.sub, auctionId, lotId);
+    return this.lotsService.findAuctionLot(user.sub, auctionId, lotId);
   }
 
   @ApiOperation({ summary: 'Update lot by id' })
@@ -82,8 +83,7 @@ export class LotsController {
     @AuthUser() user: TokenPayload,
     @Body() lot: UpdateLotDto,
   ): Promise<LotDto> {
-    await this.lotsService.assertAuctionEditable(user.sub, auctionId);
-    return this.lotsService.updateLot(user.sub, auctionId, lotId, lot);
+    return this.lotsService.updateEditableLot(user.sub, auctionId, lotId, lot);
   }
 
   @ApiOperation({ summary: 'Delete lot by id' })

--- a/server/src/modules/lots/lots.controller.ts
+++ b/server/src/modules/lots/lots.controller.ts
@@ -82,6 +82,7 @@ export class LotsController {
     @AuthUser() user: TokenPayload,
     @Body() lot: UpdateLotDto,
   ): Promise<LotDto> {
+    await this.lotsService.assertAuctionEditable(user.sub, auctionId);
     return this.lotsService.updateLot(user.sub, auctionId, lotId, lot);
   }
 

--- a/server/src/modules/lots/lots.service.spec.ts
+++ b/server/src/modules/lots/lots.service.spec.ts
@@ -1,0 +1,7 @@
+describe('LotsService', () => {
+  describe('updateLot', () => {
+    it.todo('throws BadRequestException when parent auction is STARTED');
+    it.todo('throws BadRequestException when parent auction is FINISHED');
+    it.todo('updates and returns the lot when auction is CREATED');
+  });
+});

--- a/server/src/modules/lots/lots.service.spec.ts
+++ b/server/src/modules/lots/lots.service.spec.ts
@@ -1,7 +1,143 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { LotsService } from './lots.service';
+import { Lot } from './entities/lots.entity';
+import { LotImage } from './entities/lot-image.entity';
+import { AuctionsService } from '../auctions/auctions.service';
+import { StorageService } from '../storage/storage.service';
+import { AuctionStatus } from '../auctions/entities/auction.entity';
+
+const makeLot = (overrides: Record<string, unknown> = {}): any => ({
+  id: 'lot-1',
+  name: 'Watch',
+  images: [],
+  auction: { id: 'auction-1', status: AuctionStatus.CREATED },
+  ...overrides,
+});
+
 describe('LotsService', () => {
-  describe('updateLot', () => {
-    it.todo('throws BadRequestException when parent auction is STARTED');
-    it.todo('throws BadRequestException when parent auction is FINISHED');
-    it.todo('updates and returns the lot when auction is CREATED');
+  let service: LotsService;
+  let lotsRepo: any;
+  let auctionsService: any;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LotsService,
+        {
+          provide: getRepositoryToken(Lot),
+          useValue: {
+            find: jest.fn(),
+            findOne: jest.fn(),
+            save: jest.fn(),
+            delete: jest.fn(),
+            update: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(LotImage),
+          useValue: {
+            findOne: jest.fn(),
+            save: jest.fn(),
+            delete: jest.fn(),
+          },
+        },
+        {
+          provide: AuctionsService,
+          useValue: {
+            findOne: jest.fn(),
+            findEditableOne: jest.fn(),
+            checkEditableStatus: jest.fn(),
+          },
+        },
+        {
+          provide: StorageService,
+          useValue: {
+            getPublicUrl: jest.fn().mockReturnValue('http://cdn/img.webp'),
+            createPresignedUploadUrls: jest.fn(),
+            deleteObject: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(LotsService);
+    lotsRepo = module.get(getRepositoryToken(Lot));
+    auctionsService = module.get(AuctionsService);
+  });
+
+  describe('createLots', () => {
+    it('throws BadRequestException when auction is not editable', async () => {
+      // T-002 AC: create lot is rejected when auction is STARTED or FINISHED
+      auctionsService.findEditableOne.mockRejectedValue(
+        new BadRequestException('Auction cannot be edited after it has started'),
+      );
+
+      await expect(
+        service.createLots('user-1', 'auction-1', [{ name: 'Lot 1' } as any]),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('saves and returns lots when auction is editable', async () => {
+      auctionsService.findEditableOne.mockResolvedValue({ id: 'auction-1' });
+      lotsRepo.save.mockResolvedValue([makeLot({ name: 'Lot 1' })]);
+
+      const result = await service.createLots('user-1', 'auction-1', [
+        { name: 'Lot 1' } as any,
+      ]);
+
+      expect(auctionsService.findEditableOne).toHaveBeenCalledWith(
+        'user-1',
+        'auction-1',
+      );
+      expect(result[0].name).toBe('Lot 1');
+    });
+  });
+
+  describe('updateEditableLot', () => {
+    it('throws NotFoundException when lot does not belong to the auction or user', async () => {
+      // T-002 AC: throws NotFoundException when lot not found
+      lotsRepo.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.updateEditableLot('user-1', 'auction-1', 'lot-999', {
+          name: 'X',
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws BadRequestException when auction is not editable', async () => {
+      // T-002 AC: throws BadRequestException when auction is STARTED or FINISHED
+      lotsRepo.findOne.mockResolvedValue(
+        makeLot({ auction: { id: 'auction-1', status: AuctionStatus.STARTED } }),
+      );
+      auctionsService.checkEditableStatus.mockImplementation(() => {
+        throw new BadRequestException(
+          'Auction cannot be edited after it has started',
+        );
+      });
+
+      await expect(
+        service.updateEditableLot('user-1', 'auction-1', 'lot-1', { name: 'X' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('saves and returns mapped DTO when lot is found and auction is editable', async () => {
+      // T-002 AC: saves lot and returns mapped DTO when auction and lot exist
+      lotsRepo.findOne.mockResolvedValue(makeLot());
+      lotsRepo.save.mockResolvedValue(makeLot({ name: 'New Name' }));
+
+      const result = await service.updateEditableLot(
+        'user-1',
+        'auction-1',
+        'lot-1',
+        { name: 'New Name' },
+      );
+
+      expect(lotsRepo.save).toHaveBeenCalledWith({ id: 'lot-1', name: 'New Name' });
+      expect(result.name).toBe('New Name');
+      expect(Array.isArray(result.images)).toBe(true);
+    });
   });
 });

--- a/server/src/modules/lots/lots.service.ts
+++ b/server/src/modules/lots/lots.service.ts
@@ -1,9 +1,10 @@
 import {
+  BadRequestException,
   ForbiddenException,
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
-import { Auction } from '../auctions/entities/auction.entity';
+import { Auction, AuctionStatus } from '../auctions/entities/auction.entity';
 import {
   AddLotImageDto,
   CreateLotDto,
@@ -47,6 +48,13 @@ export class LotsService {
 
   private findAuction(userId: User['id'], auctionId: Auction['id']) {
     return this.auctionsService.findOne(userId, auctionId);
+  }
+
+  async assertAuctionEditable(userId: User['id'], auctionId: Auction['id']) {
+    const auction = await this.findAuction(userId, auctionId);
+    if (auction.status !== AuctionStatus.CREATED) {
+      throw new BadRequestException('Auction cannot be edited after it has started');
+    }
   }
 
   async findAll(userId: User['id'], auctionId: Auction['id']) {
@@ -147,6 +155,7 @@ export class LotsService {
     lotId: Lot['id'],
     count: number,
   ): Promise<PresignedUrlItemDto[]> {
+    await this.assertAuctionEditable(userId, auctionId);
     await this.findLot(userId, auctionId, lotId);
 
     const s3Keys = Array.from(
@@ -163,6 +172,7 @@ export class LotsService {
     lotId: Lot['id'],
     images: AddLotImageDto[],
   ): Promise<LotImageDto[]> {
+    await this.assertAuctionEditable(userId, auctionId);
     const lot = await this.findLot(userId, auctionId, lotId);
 
     const s3KeyPrefix = getS3KeyPrefix(lotId);
@@ -191,6 +201,7 @@ export class LotsService {
     lotId: Lot['id'],
     imageId: LotImage['id'],
   ) {
+    await this.assertAuctionEditable(userId, auctionId);
     await this.findLot(userId, auctionId, lotId); // check for the owner
 
     const image = await this.lotImageRepository.findOne({

--- a/server/src/modules/lots/lots.service.ts
+++ b/server/src/modules/lots/lots.service.ts
@@ -46,10 +46,8 @@ export class LotsService {
   }
 
   async findAll(userId: User['id'], auctionId: Auction['id']) {
-    const auction = await this.auctionsService.findOne(userId, auctionId);
-
     const lots = await this.lotsRepository.find({
-      where: { auction: { id: auction.id } },
+      where: { auction: { id: auctionId, owner: { id: userId } }, },
       relations: ['buyer', 'images'],
     });
 

--- a/server/src/modules/lots/lots.service.ts
+++ b/server/src/modules/lots/lots.service.ts
@@ -1,10 +1,9 @@
 import {
-  BadRequestException,
   ForbiddenException,
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
-import { Auction, AuctionStatus } from '../auctions/entities/auction.entity';
+import { Auction } from '../auctions/entities/auction.entity';
 import {
   AddLotImageDto,
   CreateLotDto,
@@ -15,7 +14,7 @@ import {
 } from './dto/lot.dto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Lot, LotStatus } from './entities/lots.entity';
-import { EntityManager, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 import { User } from '../users/entities/user.entity';
 import { AuctionsService } from '../auctions/auctions.service';
 import { v4 as uuid } from 'uuid';
@@ -46,19 +45,8 @@ export class LotsService {
     };
   }
 
-  private findAuction(userId: User['id'], auctionId: Auction['id']) {
-    return this.auctionsService.findOne(userId, auctionId);
-  }
-
-  async assertAuctionEditable(userId: User['id'], auctionId: Auction['id']) {
-    const auction = await this.findAuction(userId, auctionId);
-    if (auction.status !== AuctionStatus.CREATED) {
-      throw new BadRequestException('Auction cannot be edited after it has started');
-    }
-  }
-
   async findAll(userId: User['id'], auctionId: Auction['id']) {
-    const auction = await this.findAuction(userId, auctionId);
+    const auction = await this.auctionsService.findOne(userId, auctionId);
 
     const lots = await this.lotsRepository.find({
       where: { auction: { id: auction.id } },
@@ -74,7 +62,10 @@ export class LotsService {
     lots: CreateLotDto[],
   ) {
     // TODO: limit lots creation count
-    const auction = await this.findAuction(userId, auctionId);
+    const auction = await this.auctionsService.findEditableOne(
+      userId,
+      auctionId,
+    );
 
     const createdLots = lots.map((lot) => ({
       ...lot,
@@ -86,36 +77,67 @@ export class LotsService {
     return savedLots.map((lot) => this.mapLotEntityToDto(lot));
   }
 
-  async findLot(
+  private async findLot(
     userId: User['id'],
     auctionId: Auction['id'],
     lotId: Lot['id'],
   ) {
-    const auction = await this.findAuction(userId, auctionId);
-
     const lot = await this.lotsRepository.findOne({
       where: {
         id: lotId,
-        auction: { id: auction.id },
+        auction: {
+          id: auctionId,
+          owner: { id: userId },
+        },
       },
+      relations: ['auction'],
     });
 
     if (!lot) {
       throw new NotFoundException('Lot not found');
     }
 
+    return lot;
+  }
+
+  async findEditableAuctionLot(
+    userId: User['id'],
+    auctionId: Auction['id'],
+    lotId: Lot['id'],
+  ) {
+    const lot = await this.findLot(userId, auctionId, lotId);
+
+    this.auctionsService.checkEditableStatus(lot.auction);
+
     return this.mapLotEntityToDto(lot);
   }
 
-  async updateLot(
+  async findAuctionLot(
+    userId: User['id'],
+    auctionId: Auction['id'],
+    lotId: Lot['id'],
+  ) {
+    const lot = await this.findLot(userId, auctionId, lotId);
+
+    return this.mapLotEntityToDto(lot);
+  }
+
+  async updateEditableLot(
     userId: User['id'],
     auctionId: Auction['id'],
     lotId: Lot['id'],
     lot: UpdateLotDto,
   ) {
-    await this.findLot(userId, auctionId, lotId);
+    const existedLot = await this.findEditableAuctionLot(
+      userId,
+      auctionId,
+      lotId,
+    );
 
-    const savedLot = await this.lotsRepository.save({ id: lotId, ...lot });
+    const savedLot = await this.lotsRepository.save({
+      id: existedLot.id,
+      ...lot,
+    });
 
     return this.mapLotEntityToDto(savedLot);
   }
@@ -125,28 +147,9 @@ export class LotsService {
     auctionId: Auction['id'],
     lotId: Lot['id'],
   ) {
-    const auction = await this.findAuction(userId, auctionId);
+    const lot = await this.findEditableAuctionLot(userId, auctionId, lotId);
 
-    await this.lotsRepository.delete({ auction, id: lotId });
-  }
-
-  async bulkMarkUnsold(auctionId: Auction['id']): Promise<void> {
-    await this.lotsRepository.update(
-      { auction: { id: auctionId }, status: LotStatus.CREATED },
-      { status: LotStatus.UNSOLD },
-    );
-  }
-
-  async bulkResetLots(
-    auctionId: Auction['id'],
-    manager: EntityManager,
-  ): Promise<void> {
-    await manager
-      .createQueryBuilder()
-      .update(Lot)
-      .set({ status: LotStatus.CREATED, soldPrice: null, buyer: null as any })
-      .where('"auctionId" = :auctionId', { auctionId })
-      .execute();
+    await this.lotsRepository.delete({ id: lot.id });
   }
 
   async createPresignedUrls(
@@ -155,8 +158,7 @@ export class LotsService {
     lotId: Lot['id'],
     count: number,
   ): Promise<PresignedUrlItemDto[]> {
-    await this.assertAuctionEditable(userId, auctionId);
-    await this.findLot(userId, auctionId, lotId);
+    await this.findEditableAuctionLot(userId, auctionId, lotId);
 
     const s3Keys = Array.from(
       { length: count },
@@ -172,8 +174,7 @@ export class LotsService {
     lotId: Lot['id'],
     images: AddLotImageDto[],
   ): Promise<LotImageDto[]> {
-    await this.assertAuctionEditable(userId, auctionId);
-    const lot = await this.findLot(userId, auctionId, lotId);
+    const lot = await this.findEditableAuctionLot(userId, auctionId, lotId);
 
     const s3KeyPrefix = getS3KeyPrefix(lotId);
 
@@ -201,8 +202,7 @@ export class LotsService {
     lotId: Lot['id'],
     imageId: LotImage['id'],
   ) {
-    await this.assertAuctionEditable(userId, auctionId);
-    await this.findLot(userId, auctionId, lotId); // check for the owner
+    await this.findEditableAuctionLot(userId, auctionId, lotId);
 
     const image = await this.lotImageRepository.findOne({
       where: { id: imageId, lot: { id: lotId } },
@@ -212,5 +212,44 @@ export class LotsService {
 
     await this.storageService.deleteObject(image.s3Key);
     await this.lotImageRepository.delete(image.id);
+  }
+
+  // Methods below work with started auction
+
+  async makeCreatedLotsUnsold(
+    userId: User['id'],
+    auctionId: Auction['id'],
+  ): Promise<void> {
+    const auction = await this.auctionsService.findOne(userId, auctionId);
+
+    await this.lotsRepository.update(
+      { auction: { id: auction.id }, status: LotStatus.CREATED },
+      { status: LotStatus.UNSOLD },
+    );
+  }
+
+  async makeLotUnsold(
+    userId: User['id'],
+    auctionId: Auction['id'],
+    lotId: Lot['id'],
+  ) {
+    const lot = await this.findAuctionLot(userId, auctionId, lotId);
+
+    await this.lotsRepository.save({ id: lot.id, status: LotStatus.UNSOLD });
+  }
+
+  async makeLotSold(
+    userId: User['id'],
+    auctionId: Auction['id'],
+    lotId: Lot['id'],
+    soldPrice: Lot['soldPrice'],
+  ) {
+    const lot = await this.findAuctionLot(userId, auctionId, lotId);
+
+    await this.lotsRepository.save({
+      id: lot.id,
+      status: LotStatus.SOLD,
+      soldPrice,
+    });
   }
 }

--- a/server/src/modules/room/room.service.spec.ts
+++ b/server/src/modules/room/room.service.spec.ts
@@ -50,6 +50,7 @@ describe('RoomService', () => {
           provide: AuctionsService,
           useValue: {
             findOne: jest.fn(),
+            findEditableOne: jest.fn(),
             startAuction: jest.fn(),
             finishAuction: jest.fn(),
             resetAuction: jest.fn(),
@@ -114,7 +115,7 @@ describe('RoomService', () => {
     const lots = [{ id: 'lot-1', name: 'Lot 1', startPrice: 100, currency: 'USD' }];
 
     beforeEach(() => {
-      auctionsService.findOne.mockResolvedValue({
+      auctionsService.findEditableOne.mockResolvedValue({
         id: 'auction-1',
         name: 'Test',
         description: null,

--- a/server/src/modules/room/room.service.spec.ts
+++ b/server/src/modules/room/room.service.spec.ts
@@ -84,8 +84,9 @@ describe('RoomService', () => {
           provide: LotsService,
           useValue: {
             findAll: jest.fn(),
-            bulkMarkUnsold: jest.fn(),
-            updateLot: jest.fn(),
+            makeCreatedLotsUnsold: jest.fn(),
+            makeLotUnsold: jest.fn(),
+            makeLotSold: jest.fn(),
           },
         },
       ],
@@ -105,7 +106,7 @@ describe('RoomService', () => {
     roomRepository.getRoom.mockResolvedValue(mockRoom);
     roomRepository.getActiveLotId.mockResolvedValue('lot-1');
     roomRepository.getActiveLotCurrentBid.mockResolvedValue(undefined);
-    lotsService.updateLot.mockResolvedValue(undefined);
+    lotsService.makeLotUnsold.mockResolvedValue(undefined);
   };
 
   describe('createRoom', () => {
@@ -167,7 +168,7 @@ describe('RoomService', () => {
     beforeEach(() => {
       stubFinishActiveLot();
       roomRepository.setActiveLot.mockResolvedValue(undefined);
-      lotsService.bulkMarkUnsold.mockResolvedValue(undefined);
+      lotsService.makeCreatedLotsUnsold.mockResolvedValue(undefined);
       auctionsService.finishAuction.mockResolvedValue(undefined);
       roomRepository.clearRoom.mockResolvedValue(undefined);
     });
@@ -206,7 +207,7 @@ describe('RoomService', () => {
 
       await service.placeNextLot(owner);
 
-      expect(lotsService.bulkMarkUnsold).toHaveBeenCalledWith('auction-1');
+      expect(lotsService.makeCreatedLotsUnsold).toHaveBeenCalledWith(owner.id, 'auction-1');
       expect(auctionsService.finishAuction).toHaveBeenCalledWith('auction-1');
       expect(roomRepository.clearRoom).toHaveBeenCalledWith('auction-1');
     });
@@ -216,7 +217,7 @@ describe('RoomService', () => {
 
       await service.placeNextLot(owner);
 
-      expect(lotsService.bulkMarkUnsold).not.toHaveBeenCalled();
+      expect(lotsService.makeCreatedLotsUnsold).not.toHaveBeenCalled();
       expect(auctionsService.finishAuction).not.toHaveBeenCalled();
       expect(roomRepository.clearRoom).not.toHaveBeenCalled();
     });
@@ -226,7 +227,7 @@ describe('RoomService', () => {
     beforeEach(() => {
       auctionsService.findOne.mockResolvedValue({ status: AuctionStatus.STARTED });
       stubFinishActiveLot();
-      lotsService.bulkMarkUnsold.mockResolvedValue(undefined);
+      lotsService.makeCreatedLotsUnsold.mockResolvedValue(undefined);
       auctionsService.finishAuction.mockResolvedValue(undefined);
       roomRepository.clearRoom.mockResolvedValue(undefined);
     });
@@ -234,7 +235,7 @@ describe('RoomService', () => {
     it('calls bulkMarkUnsold then finishAuction then clearRoom', async () => {
       await service.finishAuction(owner);
 
-      expect(lotsService.bulkMarkUnsold).toHaveBeenCalledWith('auction-1');
+      expect(lotsService.makeCreatedLotsUnsold).toHaveBeenCalledWith(owner.id, 'auction-1');
       expect(auctionsService.finishAuction).toHaveBeenCalledWith('auction-1');
       expect(roomRepository.clearRoom).toHaveBeenCalledWith('auction-1');
     });
@@ -251,7 +252,7 @@ describe('RoomService', () => {
       roomRepository.getRoom.mockResolvedValue(null);
 
       await expect(service.finishAuction(owner)).rejects.toThrow(NotFoundException);
-      expect(lotsService.bulkMarkUnsold).not.toHaveBeenCalled();
+      expect(lotsService.makeCreatedLotsUnsold).not.toHaveBeenCalled();
     });
   });
 
@@ -262,7 +263,7 @@ describe('RoomService', () => {
       stubFinishActiveLot();
       roomRepository.getNextLot.mockResolvedValue(undefined);
       roomRepository.setActiveLot.mockResolvedValue(undefined);
-      lotsService.bulkMarkUnsold.mockResolvedValue(undefined);
+      lotsService.makeCreatedLotsUnsold.mockResolvedValue(undefined);
       auctionsService.finishAuction.mockResolvedValue(undefined);
       roomRepository.clearRoom.mockResolvedValue(undefined);
     });
@@ -270,7 +271,7 @@ describe('RoomService', () => {
     it('calls bulkMarkUnsold with the auction id from the room', async () => {
       await service.placeNextLot(owner);
 
-      expect(lotsService.bulkMarkUnsold).toHaveBeenCalledWith(owner.auctionId);
+      expect(lotsService.makeCreatedLotsUnsold).toHaveBeenCalledWith(owner.id, owner.auctionId);
     });
 
     it('calls markAsFinished (auctionsService.finishAuction) with the auction id from the room', async () => {

--- a/server/src/modules/room/room.service.ts
+++ b/server/src/modules/room/room.service.ts
@@ -45,13 +45,10 @@ export class RoomService {
     const { sub: id, email } = user;
 
     const [auction, lots] = await Promise.all([
-      this.auctionsService.findOne(id, auctionId),
+      this.auctionsService.findEditableOne(id, auctionId),
       this.lotsService.findAll(id, auctionId),
     ]);
 
-    if (auction.status !== AuctionStatus.CREATED) {
-      throw new BadRequestException('Auction is not in CREATED state');
-    }
 
     const roomAuction: RoomAuction = {
       name: auction.name,

--- a/server/src/modules/room/room.service.ts
+++ b/server/src/modules/room/room.service.ts
@@ -68,7 +68,12 @@ export class RoomService {
       );
     }
 
-    const room = await this.roomRepository.createRoom(id, auctionId, roomAuction, lots);
+    const room = await this.roomRepository.createRoom(
+      id,
+      auctionId,
+      roomAuction,
+      lots,
+    );
 
     const token = this.tokenService.roomMemberToken.generate({
       sub: id,
@@ -198,7 +203,10 @@ export class RoomService {
   }
 
   async finishAuction(owner: RoomAuthorizedOwner): Promise<void> {
-    const auction = await this.auctionsService.findOne(owner.id, owner.auctionId);
+    const auction = await this.auctionsService.findOne(
+      owner.id,
+      owner.auctionId,
+    );
 
     if (auction.status !== AuctionStatus.STARTED) {
       throw new BadRequestException('Auction is not in STARTED state');
@@ -209,7 +217,7 @@ export class RoomService {
   }
 
   private async completeAuction(owner: RoomAuthorizedOwner): Promise<void> {
-    await this.lotsService.bulkMarkUnsold(owner.auctionId);
+    await this.lotsService.makeCreatedLotsUnsold(owner.id, owner.auctionId);
     await this.auctionsService.finishAuction(owner.auctionId);
     await this.roomRepository.clearRoom(owner.auctionId);
   }
@@ -230,18 +238,22 @@ export class RoomService {
     }
 
     if (!activeBid) {
-      await this.lotsService.updateLot(owner.id, room.auctionId, activeLotId, {
-        status: LotStatus.UNSOLD,
-      });
+      await this.lotsService.makeLotUnsold(
+        owner.id,
+        room.auctionId,
+        activeLotId,
+      );
 
       return;
     }
 
     await Promise.all([
-      this.lotsService.updateLot(owner.id, room.auctionId, activeLotId, {
-        status: LotStatus.SOLD,
-        soldPrice: activeBid.amount,
-      }),
+      this.lotsService.makeLotSold(
+        owner.id,
+        room.auctionId,
+        activeLotId,
+        activeBid.amount,
+      ),
       this.buyersService.saveBuyer(owner.id, room.auctionId, activeLotId, {
         name: activeBid.name,
         email: activeBid.email,


### PR DESCRIPTION
## Summary

- Exposes `finishedAt` and `status` on `AuctionDto` (server → client) and renders a status badge + finished date on the auction detail page
- Guards `PATCH /auctions/:id` and all lot mutation endpoints against edits when the auction is `STARTED` or `FINISHED`; guard lives at the controller boundary so the room service can still mark lots `SOLD`/`UNSOLD` during a live auction
- Disables `CreateLot`, `DeleteLot`, and `ManageLotImages` buttons in the CRM UI when the auction is locked

## Test plan

- [ ] Start an auction, verify lot mutation buttons are disabled in the CRM
- [ ] Confirm "Next Lot" / hammer actions still work in the room (lots marked SOLD/UNSOLD)
- [ ] Reset the auction, verify buttons re-enable
- [ ] Attempt `PATCH /auctions/:id` on a started auction via API — expect 400
- [ ] Run `cd server && npx jest --testPathPattern="lots.service|auctions.service"`
- [ ] Run `cd client && npx vitest run app/crm/auctions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)