### PR TITLE
feat: QR code join flow and mobile room fixes (FEAT-005)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,32 @@
+# Client
+# Set to your local IP (ipconfig getifaddr en0) for mobile device access, or leave as localhost
+HOSTNAME=localhost
+CLIENT_URL=http://localhost:3001
+
+# JWT — generate with: node -e "console.log(require('crypto').randomBytes(64).toString('hex'))"
+JWT_ACCESS_SECRET=
+JWT_REFRESH_SECRET=
+JWT_ROOM_MEMBER_INVITE_TOKEN_SECRET=
+JWT_ROOM_MEMBER_TOKEN_SECRET=
+JWT_ACCESS_TTL=900
+JWT_REFRESH_TTL=172800
+
+# Database
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=auction-hub-db
+DATABASE_URL=postgres://postgres:postgres@db:5432/auction-hub-db
+
+# Email — sign up at https://mailtrap.io for a free sandbox
+EMAIL_USER=
+EMAIL_PASSWORD=
+EMAIL_HOST=sandbox.smtp.mailtrap.io
+EMAIL_PORT=465
+
+# Storage — default values work with the local MinIO container (dev only)
+STORAGE_ENDPOINT=http://minio:9000
+STORAGE_ACCESS_KEY=minioadmin
+STORAGE_SECRET_KEY=minioadmin
+STORAGE_BUCKET=auction-images
+STORAGE_REGION=us-east-1
+STORAGE_PUBLIC_URL=http://localhost:9000  # use your local IP for mobile device access

--- a/client/app/api/room/[auctionId]/invite/confirm/route.ts
+++ b/client/app/api/room/[auctionId]/invite/confirm/route.ts
@@ -15,7 +15,7 @@ const confirmRoomInvite = async (req: Request, { params }: Options) => {
 
   response.cookies.set(`roomToken:${auctionId}`, data.token, {
     httpOnly: true,
-    secure: true,
+    secure: process.env.NODE_ENV === 'production',
     sameSite: 'strict',
     path: `/api/room/${auctionId}`,
   });

--- a/client/app/api/room/[auctionId]/start/route.ts
+++ b/client/app/api/room/[auctionId]/start/route.ts
@@ -13,7 +13,7 @@ const startAuction = async (_req: Request, { params }: Options) => {
 
   response.cookies.set(`roomToken:${data.room.auctionId}`, data.token, {
     httpOnly: true,
-    secure: true,
+    secure: process.env.NODE_ENV === 'production',
     sameSite: 'strict',
     path: `/api/room/${data.room.auctionId}`,
   });

--- a/client/app/api/room/route.ts
+++ b/client/app/api/room/route.ts
@@ -11,7 +11,7 @@ const createRoom = async (req: Request) => {
 
   response.cookies.set(`roomToken:${data.room.auctionId}`, data.token, {
     httpOnly: true,
-    secure: true,
+    secure: process.env.NODE_ENV === 'production',
     sameSite: 'strict',
     path: `/api/room/${data.room.auctionId}/admin`,
   });

--- a/client/app/crm/auctions/CreateAuction.button.tsx
+++ b/client/app/crm/auctions/CreateAuction.button.tsx
@@ -6,12 +6,17 @@ import { useErrorNotification } from '@/src/modules/notifications/NotifcationCon
 import { createAuction } from '@/src/api/auctions-api-client/requests/auctions';
 import { Button } from '@/ui-kit/ui/button';
 import { Plus } from 'lucide-react';
+import { useState } from 'react';
 
 export const CreateAuctionButton = () => {
   const router = useRouter();
   const handleError = useErrorNotification();
 
+  const [loading, setLoading] = useState(false);
+
   const handleCreateClick = async () => {
+    setLoading(true);
+
     const showResult = await createAuctionModal.show();
 
     if (showResult.result === 'closed') {
@@ -26,11 +31,13 @@ export const CreateAuctionButton = () => {
       router.refresh();
     } catch (error: unknown) {
       handleError(error);
+    } finally {
+      setLoading(false);
     }
   };
 
   return (
-    <Button onClick={handleCreateClick}>
+    <Button loading={loading} onClick={handleCreateClick}>
       <Plus /> Create
     </Button>
   );

--- a/client/app/crm/auctions/DeleteAuction.button.tsx
+++ b/client/app/crm/auctions/DeleteAuction.button.tsx
@@ -10,6 +10,7 @@ import { useRouter } from 'next/navigation';
 import { deleteAuction } from '@/src/api/auctions-api-client/requests/auctions';
 import { Button } from '@/ui-kit/ui/button';
 import { Trash2 } from 'lucide-react';
+import { useState } from 'react';
 
 type DeleteAuctionButtonProps = {
   auction: Auction;
@@ -19,8 +20,10 @@ export const DeleteAuctionButton = ({ auction }: DeleteAuctionButtonProps) => {
   const { showToast } = useNotification();
   const handleError = useErrorNotification();
   const router = useRouter();
+  const [loading, setLoading] = useState(false);
 
   const handleDelete = async () => {
+    setLoading(true);
     const { result } = await confirmModal.show({
       title: 'Delete Auction',
       description: `Do you really want to delete the auction "${auction.name}"?`,
@@ -40,6 +43,8 @@ export const DeleteAuctionButton = ({ auction }: DeleteAuctionButtonProps) => {
       router.refresh();
     } catch (err) {
       handleError(err);
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -49,6 +54,7 @@ export const DeleteAuctionButton = ({ auction }: DeleteAuctionButtonProps) => {
       size="icon"
       onClick={handleDelete}
       title={`Delete auction ${auction.name}`}
+      loading={loading}
     >
       <Trash2 />
     </Button>

--- a/client/app/crm/auctions/[auctionId]/CreateLot.button.tsx
+++ b/client/app/crm/auctions/[auctionId]/CreateLot.button.tsx
@@ -7,6 +7,7 @@ import { useErrorNotification } from '@/src/modules/notifications/NotifcationCon
 import { Plus } from 'lucide-react';
 import { Button } from '@/ui-kit/ui/button';
 import { lotImagesModal } from '@/app/crm/auctions/[auctionId]/LotImages.modal';
+import { useState } from 'react';
 
 type Props = {
   auctionId: Auction['id'];

--- a/client/app/crm/auctions/[auctionId]/ResetAuction.button.tsx
+++ b/client/app/crm/auctions/[auctionId]/ResetAuction.button.tsx
@@ -23,6 +23,7 @@ const ResetAuctionButton = ({ auctionId }: { auctionId: string }) => {
     if (result === 'closed') return;
 
     setIsLoading(true);
+
     try {
       await resetAuction({ auctionId });
       router.refresh();

--- a/client/app/crm/auctions/[auctionId]/StartAuction.button.tsx
+++ b/client/app/crm/auctions/[auctionId]/StartAuction.button.tsx
@@ -6,13 +6,17 @@ import { Button } from '@/ui-kit/ui/button';
 import { Play } from 'lucide-react';
 import { AdminRoomEngine } from '@/src/modules/room-engine/admin/AdminRoomEngine';
 import { useErrorNotification } from '@/src/modules/notifications/NotifcationContext';
+import { useState } from 'react';
 
 const StartAuctionButton = ({ auctionId }: { auctionId: string }) => {
   const router = useRouter();
 
   const onError = useErrorNotification();
 
+  const [loading, setLoading] = useState(false);
+
   const handleStartAuction = async () => {
+    setLoading(true);
     const { result } = await confirmModal.show({
       title: 'Start Auction?',
       description: "If auction starts, you won't be able to edit it anymore.",
@@ -26,11 +30,13 @@ const StartAuctionButton = ({ auctionId }: { auctionId: string }) => {
       router.push(`/room/${room.auctionId}/admin`);
     } catch (error) {
       onError(error);
+    } finally {
+      setLoading(false);
     }
   };
 
   return (
-    <Button variant="success" onClick={handleStartAuction}>
+    <Button loading={loading} variant="success" onClick={handleStartAuction}>
       <Play />
       Start
     </Button>

--- a/client/app/layout.tsx
+++ b/client/app/layout.tsx
@@ -1,6 +1,11 @@
 import './globals.css';
+import type { Viewport } from 'next';
 import { Geist_Mono } from 'next/font/google';
 import { NotificationProvider } from '@/src/modules/notifications/NotifcationContext';
+
+export const viewport: Viewport = {
+  viewportFit: 'cover',
+};
 
 const fontSans = Geist_Mono({ subsets: ['latin'], variable: '--font-sans' });
 

--- a/client/app/room/[auctionId]/member/ControlFooter.tsx
+++ b/client/app/room/[auctionId]/member/ControlFooter.tsx
@@ -36,7 +36,10 @@ const ControlFooter = () => {
   };
 
   return (
-    <footer className="bg-background border-t px-4 py-3 flex flex-col gap-1.5 flex-shrink-0">
+    <footer
+      className="bg-background border-t px-4 pt-3 flex flex-col gap-1.5 flex-shrink-0 relative z-10"
+      style={{ paddingBottom: 'max(12px, env(safe-area-inset-bottom))' }}
+    >
       <div className="max-w-lg mx-auto w-full flex flex-col gap-1.5">
         <Button
           disabled={isSubmitBidDisabled}

--- a/client/app/room/[auctionId]/member/page.tsx
+++ b/client/app/room/[auctionId]/member/page.tsx
@@ -18,7 +18,7 @@ const RoomMemberPage = () => {
   } = useMemberRoomContext();
 
   return (
-    <div className="h-screen flex flex-col overflow-hidden bg-muted/30">
+    <div className="h-dvh flex flex-col overflow-hidden bg-muted/30">
       <RoomHeader isLoading={isLoading} title={auction?.name} description={auction?.description} />
 
       <main className="flex-1 overflow-y-auto pb-24 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">

--- a/client/app/room/[auctionId]/page.tsx
+++ b/client/app/room/[auctionId]/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import QRCode from 'react-qr-code';
 import RoomHeader from './components/RoomHeader';
 import CurrentLot from './components/CurrentLot';
 import RoomCard from './components/RoomCard';
@@ -9,75 +10,18 @@ import { RoomErrorBoundary } from './components/RoomErrorBoundary';
 import { PublicRoomProvider } from '@/src/modules/room-engine/public/PublicRoomContext';
 import { usePublicRoom } from '@/src/modules/room-engine/public/hooks/usePublicRoom';
 
-// ─── QR placeholder SVG ───────────────────────────────────────────────────────
+const useInviteUrl = () => {
+  const auctionId = useAuctionId();
 
-const QrPlaceholder = () => (
-  <svg
-    viewBox="0 0 90 90"
-    xmlns="http://www.w3.org/2000/svg"
-    className="w-4/5 h-4/5 max-w-[140px] max-h-[140px]"
-  >
-    <rect
-      x="5"
-      y="5"
-      width="28"
-      height="28"
-      rx="3"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2.5"
-    />
-    <rect x="11" y="11" width="16" height="16" rx="1" fill="currentColor" />
-    <rect
-      x="57"
-      y="5"
-      width="28"
-      height="28"
-      rx="3"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2.5"
-    />
-    <rect x="63" y="11" width="16" height="16" rx="1" fill="currentColor" />
-    <rect
-      x="5"
-      y="57"
-      width="28"
-      height="28"
-      rx="3"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2.5"
-    />
-    <rect x="11" y="63" width="16" height="16" rx="1" fill="currentColor" />
-    <rect x="42" y="5" width="6" height="6" rx="1" fill="currentColor" />
-    <rect x="42" y="13" width="6" height="6" rx="1" fill="currentColor" />
-    <rect x="42" y="21" width="6" height="6" rx="1" fill="currentColor" />
-    <rect x="5" y="42" width="6" height="6" rx="1" fill="currentColor" />
-    <rect x="13" y="42" width="6" height="6" rx="1" fill="currentColor" />
-    <rect x="21" y="42" width="6" height="6" rx="1" fill="currentColor" />
-    <rect x="42" y="42" width="6" height="6" rx="1" fill="currentColor" />
-    <rect x="50" y="42" width="6" height="6" rx="1" fill="currentColor" />
-    <rect x="58" y="42" width="6" height="6" rx="1" fill="currentColor" />
-    <rect x="66" y="42" width="6" height="6" rx="1" fill="currentColor" />
-    <rect x="74" y="42" width="6" height="6" rx="1" fill="currentColor" />
-    <rect x="42" y="50" width="6" height="6" rx="1" fill="currentColor" />
-    <rect x="58" y="50" width="6" height="6" rx="1" fill="currentColor" />
-    <rect x="74" y="50" width="6" height="6" rx="1" fill="currentColor" />
-    <rect x="42" y="58" width="6" height="6" rx="1" fill="currentColor" />
-    <rect x="50" y="58" width="6" height="6" rx="1" fill="currentColor" />
-    <rect x="66" y="58" width="6" height="6" rx="1" fill="currentColor" />
-    <rect x="42" y="66" width="6" height="6" rx="1" fill="currentColor" />
-    <rect x="58" y="66" width="6" height="6" rx="1" fill="currentColor" />
-    <rect x="42" y="74" width="6" height="6" rx="1" fill="currentColor" />
-    <rect x="50" y="74" width="6" height="6" rx="1" fill="currentColor" />
-    <rect x="66" y="74" width="6" height="6" rx="1" fill="currentColor" />
-    <rect x="74" y="74" width="6" height="6" rx="1" fill="currentColor" />
-  </svg>
-);
+  if (!window) return '';
+
+  return `${window.location.origin}/room/${auctionId}/invite`;
+};
 
 const RoomDisplayPage = () => {
   const { isLoading, auction, activeLot, bids } = usePublicRoom();
+
+  const inviteUrl = useInviteUrl();
 
   return (
     <div className="h-screen flex flex-col bg-muted/30 overflow-y-auto md:overflow-hidden">
@@ -89,7 +33,7 @@ const RoomDisplayPage = () => {
         <div className="flex flex-col gap-3 md:grid md:grid-rows-2 md:min-h-0">
           <RoomCard title="Join auction">
             <div className="h-40 md:h-auto md:flex-1 md:min-h-0 w-full bg-muted rounded-md flex items-center justify-center">
-              <QrPlaceholder />
+              <QRCode value={inviteUrl} size={140} fgColor="currentColor" bgColor="transparent" />
             </div>
             <p className="text-sm font-medium text-center">Scan to join</p>
           </RoomCard>

--- a/client/next.config.ts
+++ b/client/next.config.ts
@@ -1,12 +1,14 @@
 import type { NextConfig } from 'next';
 
+const storageUrl = new URL(process.env.STORAGE_PUBLIC_URL ?? 'http://localhost:9000');
+
 const nextConfig: NextConfig = {
   images: {
     remotePatterns: [
       {
-        protocol: 'http',
-        hostname: 'localhost',
-        port: '9000',
+        protocol: storageUrl.protocol.replace(':', '') as 'http' | 'https',
+        hostname: storageUrl.hostname,
+        port: storageUrl.port,
         pathname: '/**',
       },
       {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -28,6 +28,7 @@
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-hook-form": "^7.71.2",
+        "react-qr-code": "^2.0.21",
         "socket.io-client": "^4.8.1",
         "tailwind-merge": "^3.4.0",
         "tw-animate-css": "^1.4.0",
@@ -7250,7 +7251,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -7700,7 +7700,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -8023,7 +8022,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8420,7 +8418,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -8443,6 +8440,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/qr.js": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz",
+      "integrity": "sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ==",
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -8647,8 +8650,20 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-qr-code": {
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/react-qr-code/-/react-qr-code-2.0.21.tgz",
+      "integrity": "sha512-xaywjo0eaF4S3LOz6ns5eoPbM2E+q9HYl4VATYpxK4bBniOhQ9noY2RJ9G4SnZFhUwzx63FUT6KdHzfKgUwyuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1",
+        "qr.js": "0.0.0"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",

--- a/client/package.json
+++ b/client/package.json
@@ -28,6 +28,7 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-hook-form": "^7.71.2",
+    "react-qr-code": "^2.0.21",
     "socket.io-client": "^4.8.1",
     "tailwind-merge": "^3.4.0",
     "tw-animate-css": "^1.4.0",

--- a/client/src/modules/room-engine/admin/AdminRoomEngine.ts
+++ b/client/src/modules/room-engine/admin/AdminRoomEngine.ts
@@ -79,17 +79,15 @@ export class AdminRoomEngine extends RoomEngine<AdminRoomData> {
       this.setState({ activeLot: lot, bids: [] });
     });
 
-    this.socket.onEvent<RoomMember>('memberJoined', (member) => {
-      this.setState({ members: [...this.data.members, member] });
-    });
-
     this.socket.onEvent<RoomInvite>('newInvite', (invite) => {
-      this.setState({ invites: [...this.data.invites, invite] });
+      const exists = this.data.invites.some((inv) => inv.id === invite.id);
+      if (!exists) this.setState({ invites: [...this.data.invites, invite] });
     });
 
     this.socket.onEvent<RoomMember>('newMember', (member) => {
+      const exists = this.data.members.some((m) => m.id === member.id);
       this.setState({
-        members: [...this.data.members, member],
+        members: exists ? this.data.members : [...this.data.members, member],
         invites: this.data.invites.filter((inv) => inv.id !== member.id),
       });
     });

--- a/client/src/modules/room-engine/admin/hooks/useAdminEngine.ts
+++ b/client/src/modules/room-engine/admin/hooks/useAdminEngine.ts
@@ -1,11 +1,11 @@
 import { useMemo } from 'react';
 import { AdminRoomEngine } from '@/src/modules/room-engine/admin/AdminRoomEngine';
 import BaseSocket from '@/src/sockets/base-socket';
+import { getRoomSocketUrl } from '@/src/sockets/socket-url';
 
 export const useAdminEngine = (auctionId: string) => {
   return useMemo(
-    () =>
-      new AdminRoomEngine(auctionId, new BaseSocket(process.env.NEXT_PUBLIC_API_WEBSOCKET_URL ?? '')),
+    () => new AdminRoomEngine(auctionId, new BaseSocket(getRoomSocketUrl())),
     [auctionId]
   );
 };

--- a/client/src/modules/room-engine/member/MemberRoomEngine.ts
+++ b/client/src/modules/room-engine/member/MemberRoomEngine.ts
@@ -46,7 +46,6 @@ export class MemberRoomEngine extends RoomEngine<MemberRoomData> {
   }
 
   get isWinning(): boolean {
-    console.log(this.data.user, this.leadingBid);
     return (
       this.data.user != null &&
       this.leadingBid != null &&

--- a/client/src/modules/room-engine/member/hooks/useMemberEngine.ts
+++ b/client/src/modules/room-engine/member/hooks/useMemberEngine.ts
@@ -1,11 +1,11 @@
 import { useMemo } from 'react';
 import { MemberRoomEngine } from '@/src/modules/room-engine/member/MemberRoomEngine';
 import BaseSocket from '@/src/sockets/base-socket';
+import { getRoomSocketUrl } from '@/src/sockets/socket-url';
 
 export const useMemberEngine = (auctionId: string) => {
   const engine = useMemo(
-    () =>
-      new MemberRoomEngine(auctionId, new BaseSocket(process.env.NEXT_PUBLIC_API_WEBSOCKET_URL ?? '')),
+    () => new MemberRoomEngine(auctionId, new BaseSocket(getRoomSocketUrl())),
     [auctionId]
   );
 

--- a/client/src/modules/room-engine/member/hooks/useMemberRoom.ts
+++ b/client/src/modules/room-engine/member/hooks/useMemberRoom.ts
@@ -5,6 +5,8 @@ import { useMemberRoomContext } from '@/src/modules/room-engine/member/MemberRoo
 export function useMemberRoom() {
   const { engine, state } = useMemberRoomContext();
 
+  if (state.error) throw new Error(state.error);
+
   return {
     engine,
     isLoading: state.isLoading,

--- a/client/src/modules/room-engine/public/hooks/usePublicEngine.ts
+++ b/client/src/modules/room-engine/public/hooks/usePublicEngine.ts
@@ -1,11 +1,11 @@
 import { useMemo } from 'react';
 import { PublicRoomEngine } from '@/src/modules/room-engine/public/PublicRoomEngine';
 import BaseSocket from '@/src/sockets/base-socket';
+import { getRoomSocketUrl } from '@/src/sockets/socket-url';
 
 export const usePublicEngine = (auctionId: string) => {
   return useMemo(
-    () =>
-      new PublicRoomEngine(auctionId, new BaseSocket(process.env.NEXT_PUBLIC_API_WEBSOCKET_URL ?? '')),
+    () => new PublicRoomEngine(auctionId, new BaseSocket(getRoomSocketUrl())),
     [auctionId]
   );
 };

--- a/client/src/sockets/base-socket.ts
+++ b/client/src/sockets/base-socket.ts
@@ -6,7 +6,8 @@ class BaseSocket {
   constructor(private readonly SOCKET_URL: string) {}
 
   connect(token: string): Promise<void> {
-    console.log('Connecting to', this.SOCKET_URL);
+    if (this.socket) return Promise.resolve();
+
     return new Promise((resolve, reject) => {
       this.socket = io(this.SOCKET_URL, {
         transports: ['websocket'],

--- a/client/src/sockets/socket-url.ts
+++ b/client/src/sockets/socket-url.ts
@@ -1,0 +1,4 @@
+export const getRoomSocketUrl = () => {
+  if (typeof window === 'undefined') return '';
+  return `${window.location.protocol}//${window.location.hostname}:3000/ws/room`;
+};

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,9 +16,9 @@ services:
     image: postgres:16
     container_name: auction-postgres
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: auction-hub-db
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
     ports:
       - "5433:5432"
     volumes:
@@ -79,22 +79,20 @@ services:
       CHOKIDAR_INTERVAL: "300"
       PORT: 3000
       REDIS_URL: redis://redis:6379
-      DATABASE_URL: postgres://postgres:postgres@db:5432/auction-hub-db
-      CLIENT_URL: http://localhost:3001
+      DATABASE_URL: ${DATABASE_URL}
+      CLIENT_URL: ${CLIENT_URL}
       JWT_ACCESS_SECRET: ${JWT_ACCESS_SECRET}
       JWT_REFRESH_SECRET: ${JWT_REFRESH_SECRET}
       JWT_ROOM_MEMBER_INVITE_TOKEN_SECRET: ${JWT_ROOM_MEMBER_INVITE_TOKEN_SECRET}
       JWT_ROOM_MEMBER_TOKEN_SECRET: ${JWT_ROOM_MEMBER_TOKEN_SECRET}
-      JWT_ACCESS_TTL: 900
-      JWT_REFRESH_TTL: 172800
-      # Storage (MinIO for dev)
-      STORAGE_ENDPOINT: http://minio:9000
+      JWT_ACCESS_TTL: ${JWT_ACCESS_TTL}
+      JWT_REFRESH_TTL: ${JWT_REFRESH_TTL}
+      STORAGE_ENDPOINT: ${STORAGE_ENDPOINT}
       STORAGE_ACCESS_KEY: ${STORAGE_ACCESS_KEY}
       STORAGE_SECRET_KEY: ${STORAGE_SECRET_KEY}
       STORAGE_BUCKET: ${STORAGE_BUCKET}
       STORAGE_REGION: ${STORAGE_REGION}
-      # URL for browser (not for a docker image)
-      STORAGE_PUBLIC_URL: http://localhost:9000
+      STORAGE_PUBLIC_URL: ${STORAGE_PUBLIC_URL}
       EMAIL_USER: ${EMAIL_USER}
       EMAIL_PASSWORD: ${EMAIL_PASSWORD}
       EMAIL_HOST: ${EMAIL_HOST}
@@ -118,15 +116,14 @@ services:
       NODE_ENV: production
       PORT: 3000
       REDIS_URL: redis://redis:6379
-      DATABASE_URL: postgres://postgres:postgres@db:5432/auction-hub-db
-      CLIENT_URL: http://localhost:3001
+      DATABASE_URL: ${DATABASE_URL}
+      CLIENT_URL: ${CLIENT_URL}
       JWT_ACCESS_SECRET: ${JWT_ACCESS_SECRET}
       JWT_REFRESH_SECRET: ${JWT_REFRESH_SECRET}
       JWT_ROOM_MEMBER_INVITE_TOKEN_SECRET: ${JWT_ROOM_MEMBER_INVITE_TOKEN_SECRET}
       JWT_ROOM_MEMBER_TOKEN_SECRET: ${JWT_ROOM_MEMBER_TOKEN_SECRET}
-      JWT_ACCESS_TTL: 900
-      JWT_REFRESH_TTL: 172800
-      # Storage (AWS S3 for prod)
+      JWT_ACCESS_TTL: ${JWT_ACCESS_TTL}
+      JWT_REFRESH_TTL: ${JWT_REFRESH_TTL}
       STORAGE_ENDPOINT: ${STORAGE_ENDPOINT}
       STORAGE_ACCESS_KEY: ${STORAGE_ACCESS_KEY}
       STORAGE_SECRET_KEY: ${STORAGE_SECRET_KEY}
@@ -153,7 +150,7 @@ services:
     command: sh -c "npm run migration:generate"
     environment:
       NODE_ENV: development
-      DATABASE_URL: postgres://postgres:postgres@db:5432/auction-hub-db
+      DATABASE_URL: ${DATABASE_URL}
     depends_on:
       - db
     volumes:
@@ -169,16 +166,16 @@ services:
     environment:
       NODE_ENV: development
       PORT: 3001
+      HOSTNAME: ${HOSTNAME:-localhost}
       CHOKIDAR_USEPOLLING: true
-      NEXT_PUBLIC_API_WEBSOCKET_URL: http://localhost:3000/ws/room
       API_URL: http://api-dev:3000/api/v1
       REDIS_URL: redis://redis:6379
       JWT_ACCESS_SECRET: ${JWT_ACCESS_SECRET}
       JWT_REFRESH_SECRET: ${JWT_REFRESH_SECRET}
       JWT_ROOM_MEMBER_INVITE_TOKEN_SECRET: ${JWT_ROOM_MEMBER_INVITE_TOKEN_SECRET}
       JWT_ROOM_MEMBER_TOKEN_SECRET: ${JWT_ROOM_MEMBER_TOKEN_SECRET}
-      JWT_ACCESS_TTL: 900
-      JWT_REFRESH_TTL: 172800
+      JWT_ACCESS_TTL: ${JWT_ACCESS_TTL}
+      JWT_REFRESH_TTL: ${JWT_REFRESH_TTL}
     ports:
       - "3001:3001"
     volumes:
@@ -197,15 +194,15 @@ services:
     environment:
       NODE_ENV: production
       PORT: 3001
-      NEXT_PUBLIC_API_WEBSOCKET_URL: http://localhost:3000/ws/room
+      HOSTNAME: ${HOSTNAME:-localhost}
       API_URL: http://api-prod:3000/api/v1
       REDIS_URL: redis://redis:6379
       JWT_ACCESS_SECRET: ${JWT_ACCESS_SECRET}
       JWT_REFRESH_SECRET: ${JWT_REFRESH_SECRET}
       JWT_ROOM_MEMBER_INVITE_TOKEN_SECRET: ${JWT_ROOM_MEMBER_INVITE_TOKEN_SECRET}
       JWT_ROOM_MEMBER_TOKEN_SECRET: ${JWT_ROOM_MEMBER_TOKEN_SECRET}
-      JWT_ACCESS_TTL: 900
-      JWT_REFRESH_TTL: 172800
+      JWT_ACCESS_TTL: ${JWT_ACCESS_TTL}
+      JWT_REFRESH_TTL: ${JWT_REFRESH_TTL}
     ports:
       - "3001:3001"
     depends_on:

--- a/docs/features/FEAT-005-room-qr-code/03-adr.md
+++ b/docs/features/FEAT-005-room-qr-code/03-adr.md
@@ -1,0 +1,153 @@
+---
+ADR ID: ADR-FEAT-005-01
+Status: Proposed
+Date: 2026-05-19
+Feature: FEAT-005-room-qr-code
+Decision makers: sdlc-adr
+Supersedes: —
+---
+
+# ADR-FEAT-005-01: QR Code Generation Strategy for Room Display Page
+
+## 1. Context
+
+The public room display page (`/room/:auctionId`) shows a static SVG placeholder in a
+"Join auction" card. This must be replaced with a real, scannable QR code that encodes the
+invite registration URL: `<origin>/room/<auctionId>/invite`.
+
+When scanned, this URL takes an attendee to the invite form (name + email). The existing
+invite flow (FEAT-002) then sends an email with a confirm link
+(`/room/<auctionId>/invite/confirm?token=…`) that authenticates the member.
+
+The `auctionId` is already available on the page via the `useAuctionId()` hook. No new
+data-fetching is required — the QR input is a deterministic URL derived from a value
+already in scope.
+
+No feature spec exists for FEAT-005; this ADR is written from a thin brief. The invite URL
+shape is treated as settled by FEAT-002's implementation.
+
+## 2. Decision Drivers
+
+1. **Minimal implementation surface** — the change is a single component swap; the solution
+   should not introduce server changes or new API endpoints.
+2. **No external service dependencies** — the QR must render without calling a third-party
+   API, both for privacy (the invite URL contains the auctionId) and offline resilience.
+3. **Visual fidelity** — the output must be a real, scannable QR code (not decorative).
+   Styling should respect the existing Tailwind + shadcn/ui conventions (SVG preferred so
+   `currentColor` theming applies).
+4. **Dependency footprint** — bundle size impact should be negligible (<10 kB gzipped).
+5. **Maintenance** — the chosen library should be actively maintained and widely adopted.
+
+## 3. Options Considered
+
+### Option A — Client-side React QR library (`react-qr-code`)
+
+A lightweight React component that renders a real QR code as inline SVG directly in the
+browser. Drop-in replacement for `QrPlaceholder`:
+`<QRCode value={inviteUrl} size={140} />`.
+
+- **Pros:** Zero server changes; renders synchronously (no loading state); SVG output
+  inherits text color and scales cleanly; works offline; ~3 kB gzipped.
+- **Cons:** Adds one npm dependency to the client workspace.
+- **Estimated effort:** ~30 min (install, swap component, verify scanability).
+
+---
+
+### Option B — Server-side NestJS QR endpoint
+
+Add a new `GET /room/:auctionId/qr` endpoint that generates a QR PNG/SVG using a
+server-side library (e.g., `qrcode`) and returns it as an image. The client renders
+`<img src="/api/room/{auctionId}/qr" />`.
+
+- **Pros:** QR generation logic lives server-side; response could be cached at the CDN layer.
+- **Cons:** Requires a new controller route, a new server dependency, an async image load
+  (introduces a loading state), and meaningfully more code — all for a URL that is
+  completely static and already known on the client. No practical benefit over Option A for
+  this use case.
+- **Estimated effort:** ~3–4 h (endpoint, dto, test, client fetch wiring).
+
+---
+
+### Option C — External QR code API (e.g., `api.qrserver.com`)
+
+Render `<img src="https://api.qrserver.com/v1/create-qr-code/?data=<encodedUrl>&size=140x140" />`
+with zero code beyond a URL construction.
+
+- **Pros:** No library or server code needed.
+- **Cons:** Sends the invite URL to a third-party server on every page render (privacy
+  concern); fails offline or if the service is unavailable; introduces an external runtime
+  dependency that is outside the project's control.
+- **Estimated effort:** ~10 min, but violates driver #2.
+
+## 4. Comparison
+
+| Criterion                       | A — Client library | B — Server endpoint | C — External API |
+|---------------------------------|--------------------|---------------------|------------------|
+| Server changes required         | None               | New route + test    | None             |
+| New npm dependency              | 1 client pkg       | 1 server pkg        | None             |
+| Renders offline                 | Yes                | Yes (once served)   | No               |
+| Privacy (no 3rd-party)          | Yes                | Yes                 | **No**           |
+| Bundle size impact              | ~3 kB gzipped      | 0 client            | 0 client         |
+| Implementation effort           | Low                | High                | Trivial but rejected |
+| SVG / `currentColor` theming    | Yes                | Depends on format   | No (PNG img tag) |
+
+## 5. Decision
+
+**Chosen: Option A — client-side React QR library (`react-qr-code`).**
+
+Drivers #1 (minimal surface) and #2 (no external service) eliminate Options B and C
+respectively. Option A satisfies all five drivers: no server changes, no third-party
+calls, SVG output that integrates with the existing Tailwind theme, negligible bundle
+cost, and an active library with strong adoption.
+
+The single tradeoff — adding one npm package — is accepted; the client workspace already
+depends on multiple third-party libraries and a ~3 kB addition is within acceptable bounds.
+
+## 6. Tradeoffs
+
+| Gained                                              | Sacrificed                                    |
+|-----------------------------------------------------|-----------------------------------------------|
+| Real, scannable QR with no server or network dep    | One additional client dependency              |
+| SVG output — scales to any size, respects theme     | Server-side cacheability (not needed here)    |
+| Synchronous render — no loading state needed        | —                                             |
+
+## 7. Known Limitations
+
+- This decision covers only the display of a static invite URL. If the invite flow ever
+  moves to pre-generated tokens embedded in QR codes (rather than token-per-email), the QR
+  content strategy must be revisited (content changes, this library still applies).
+- The QR code size is fixed at 140 px max in the current layout. Accessibility at small
+  print sizes was not evaluated; this is a display-only screen constraint.
+- Error correction level defaults to `L` (low) in most libraries. If a logo is ever
+  overlaid on the QR code, level must be raised to `H`; that is a one-line config change.
+
+## 8. Future Optimization Opportunities
+
+- **Logo overlay**: When branding requirements arrive, switch `react-qr-code`'s
+  `bgColor`/`fgColor` and add a centered logo via absolute positioning — no library change
+  needed.
+- **Token-embedded QR**: If the invite flow adds pre-auth tokens (bypass email step),
+  replace the static URL with a signed short-lived URL. The rendering approach is unchanged;
+  only the `value` prop changes.
+- **Print support**: The SVG output is already print-friendly. A `window.print()`
+  button can be added without touching the QR implementation.
+
+## 9. Consequences
+
+- **Client dependency**: `react-qr-code` added to `client/package.json`.
+- **Code change**: `QrPlaceholder` (inline SVG, ~70 lines) replaced by a `<QRCode>`
+  wrapper component in `client/app/room/[auctionId]/page.tsx`.
+- **URL construction**: `inviteUrl` derived as
+  `${window.location.origin}/room/${auctionId}/invite` using the existing `useAuctionId()`
+  hook.
+- **No server changes**, no new API routes, no migration, no Redis changes.
+- **Testing**: Visual/scanability test on the public room page. No unit test needed for a
+  pure prop-driven library component.
+
+## 10. References
+
+- Invite flow implementation: FEAT-002-room-identity-refactor
+  (`docs/features/FEAT-002-room-identity-refactor/03-adr.md`)
+- Usage site: `client/app/room/[auctionId]/page.tsx` (lines 14–77, `QrPlaceholder`)
+- Invite registration page: `client/app/room/[auctionId]/invite/page.tsx`
+- `react-qr-code` npm package (model knowledge; no WebSearch performed)

--- a/server/src/modules/lots/lots.service.ts
+++ b/server/src/modules/lots/lots.service.ts
@@ -47,8 +47,9 @@ export class LotsService {
 
   async findAll(userId: User['id'], auctionId: Auction['id']) {
     const lots = await this.lotsRepository.find({
-      where: { auction: { id: auctionId, owner: { id: userId } }, },
+      where: { auction: { id: auctionId, owner: { id: userId } } },
       relations: ['buyer', 'images'],
+      order: { createdAt: 'ASC' },
     });
 
     return lots.map((lot) => this.mapLotEntityToDto(lot));


### PR DESCRIPTION
## Summary

- **QR code join flow** — replaced placeholder SVG with real `react-qr-code`; invite URL derived dynamically from `window.location.origin` so it works from any device on the local network
- **iOS Safari Place Bid fix** — container uses `h-dvh` instead of `h-screen`; footer gets `viewport-fit=cover` + `env(safe-area-inset-bottom)` padding so the button is always visible and tappable above the home indicator
- **WebSocket URL** — derived from `window.location` at runtime; removed `NEXT_PUBLIC_API_WEBSOCKET_URL` env var entirely
- **Room auth cookie** — `secure` flag now only set in production, fixing 401s on HTTP (local IP)
- **Participants deduplication** — added existence check before appending `newInvite` and `newMember` socket events
- **Env config** — moved all hardcoded `docker-compose.yml` values to `.env`; added `.env.example` for onboarding

## Test plan

- [ ] Open room display page in browser — QR code renders with correct invite URL
- [ ] Scan QR code from phone — lands on invite page with correct auction
- [ ] Open member room on iPhone (Safari) — Place Bid button fully visible and tappable without scrolling
- [ ] Connect to room over local IP — no 401 errors on room start/join
- [ ] Send invite from admin room — participant appears once in the list, not duplicated
- [ ] Copy `.env.example` → `.env`, run `npm run dev` — full stack starts without modification

🤖 Generated with [Claude Code](https://claude.com/claude-code)